### PR TITLE
Support for restrictions over Classes and Object Properties.

### DIFF
--- a/examples/example/example.owl
+++ b/examples/example/example.owl
@@ -238,6 +238,47 @@
     
 
 
+    <!-- https://w3id.org/example#testObjectIntersectionOf -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/example#testObjectIntersectionOf">
+        <rdfs:domain rdf:resource="https://w3id.org/example#Person"/>
+        <rdfs:range>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="https://w3id.org/example#StudentRecord"/>
+                    <rdf:Description rdf:about="https://w3id.org/example#StudyProgram"/>
+                </owl:intersectionOf>
+            </owl:Class>
+        </rdfs:range>
+        <terms:description xml:lang="en">This is a property to test a complex ObjectIntersectionOf. (Note that range values are added only for test purposes).</terms:description>
+        <rdfs:label xml:lang="en">test ObjectIntersectionOf</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://w3id.org/example#testObjectUnionOf -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/example#testObjectUnionOf">
+        <rdfs:domain rdf:resource="https://w3id.org/example#Person"/>
+        <rdfs:range>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="https://w3id.org/example#Course"/>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="https://w3id.org/example#Department"/>
+                            <rdf:Description rdf:about="https://w3id.org/example#StudyProgram"/>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:unionOf>
+            </owl:Class>
+        </rdfs:range>
+        <terms:description xml:lang="en">This is a property to test a complex ObjectUnionOf restriction that includes a ObjectIntersectionOf. (Note that range values are added only for test purposes).</terms:description>
+        <rdfs:label xml:lang="en">test ObjectUnionOf</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
     <!-- https://w3id.org/example#worksIn -->
 
     <owl:ObjectProperty rdf:about="https://w3id.org/example#worksIn">
@@ -586,9 +627,9 @@
     
 
 
-    <!-- https://w3id.org/example#ProfessorInArtificalIntelligence -->
+    <!-- https://w3id.org/example#ProfessorInArtificialIntelligence -->
 
-    <owl:Class rdf:about="https://w3id.org/example#ProfessorInArtificalIntelligence">
+    <owl:Class rdf:about="https://w3id.org/example#ProfessorInArtificialIntelligence">
         <rdfs:subClassOf>
             <owl:Class>
                 <owl:intersectionOf rdf:parseType="Collection">
@@ -611,7 +652,7 @@
     <owl:Class rdf:about="https://w3id.org/example#ProfessorInOtherDepartment">
         <rdfs:subClassOf>
             <owl:Class>
-                <owl:complementOf rdf:resource="https://w3id.org/example#ProfessorInArtificalIntelligence"/>
+                <owl:complementOf rdf:resource="https://w3id.org/example#ProfessorInArtificialIntelligence"/>
             </owl:Class>
         </rdfs:subClassOf>
         <terms:description xml:lang="en">All professors who doesn&apos;t belong to the Artificial Intelligence Department.</terms:description>

--- a/examples/example/readme.md
+++ b/examples/example/readme.md
@@ -1,5 +1,0 @@
-## Example ontology
-
-This example illustrates several ontology constructs to show how to represent them in the OAS.
-
-Note that this example was tested on macOS (hence the file path) and the working directory is assumed to be the above the "examples" folder

--- a/examples/restrictions/config.yaml
+++ b/examples/restrictions/config.yaml
@@ -1,16 +1,16 @@
 ontologies:
-  - examples/example/example.owl
-name: example
+  - examples/restrictions/example.owl
+name: Restrictions example
 output_dir: outputs
 
 openapi:
   openapi: 3.0.1
   info:
-    description: This is the API for the example ontology
-    title: Example ontology
+    description: This is the API for the restrictions example ontology
+    title: Restrictions example ontology
     version: v1.5.0
   externalDocs:
-    description: Example ontology
+    description: Restrictions example ontology
     url: https://w3id.org/example
   servers:
     - url: http://localhost:8080/v1.5.0

--- a/examples/restrictions/example.owl
+++ b/examples/restrictions/example.owl
@@ -97,6 +97,23 @@
     
 
 
+    <!-- https://w3id.org/example#author -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/example#author">
+        <rdfs:domain rdf:resource="https://w3id.org/example#StudyMaterial"/>
+        <rdfs:range>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="https://w3id.org/example#Organization"/>
+                    <rdf:Description rdf:about="https://w3id.org/example#Person"/>
+                </owl:unionOf>
+            </owl:Class>
+        </rdfs:range>
+        <rdfs:label xml:lang="en">author</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
     <!-- https://w3id.org/example#belongsTo -->
 
     <owl:ObjectProperty rdf:about="https://w3id.org/example#belongsTo">
@@ -127,12 +144,39 @@
     
 
 
-    <!-- https://w3id.org/example#hasDeparment -->
+    <!-- https://w3id.org/example#hasDegree -->
 
-    <owl:ObjectProperty rdf:about="https://w3id.org/example#hasDeparment">
+    <owl:ObjectProperty rdf:about="https://w3id.org/example#hasDegree">
+        <rdfs:domain rdf:resource="https://w3id.org/example#Person"/>
+        <rdfs:range rdf:resource="https://w3id.org/example#Degree"/>
+        <rdfs:label xml:lang="en">has degree</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://w3id.org/example#hasDepartment -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/example#hasDepartment">
         <rdfs:domain rdf:resource="https://w3id.org/example#University"/>
         <rdfs:range rdf:resource="https://w3id.org/example#Department"/>
         <rdfs:label xml:lang="en">has department</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://w3id.org/example#hasEvaluationMethod -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/example#hasEvaluationMethod">
+        <rdfs:domain rdf:resource="https://w3id.org/example#Course"/>
+        <rdfs:range>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="https://w3id.org/example#Assignment"/>
+                    <rdf:Description rdf:about="https://w3id.org/example#Exam"/>
+                </owl:intersectionOf>
+            </owl:Class>
+        </rdfs:range>
+        <rdfs:label xml:lang="en">has evaluation method</rdfs:label>
     </owl:ObjectProperty>
     
 
@@ -161,6 +205,7 @@
     <!-- https://w3id.org/example#hasRector -->
 
     <owl:ObjectProperty rdf:about="https://w3id.org/example#hasRector">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
         <rdfs:domain rdf:resource="https://w3id.org/example#University"/>
         <rdfs:range rdf:resource="https://w3id.org/example#Professor"/>
         <rdfs:label xml:lang="en">has rector</rdfs:label>
@@ -184,6 +229,16 @@
         <rdfs:domain rdf:resource="https://w3id.org/example#Course"/>
         <rdfs:range rdf:resource="https://w3id.org/example#Student"/>
         <rdfs:label xml:lang="en">has student enrolled</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://w3id.org/example#hasStudyMaterial -->
+
+    <owl:ObjectProperty rdf:about="https://w3id.org/example#hasStudyMaterial">
+        <rdfs:domain rdf:resource="https://w3id.org/example#Course"/>
+        <rdfs:range rdf:resource="https://w3id.org/example#StudyMaterial"/>
+        <rdfs:label xml:lang="en">has study material</rdfs:label>
     </owl:ObjectProperty>
     
 
@@ -250,7 +305,7 @@
                 </owl:intersectionOf>
             </owl:Class>
         </rdfs:range>
-        <terms:description xml:lang="en">This is a property to test a complex ObjectIntersectionOf. (Note that range values are added only for test purposes).</terms:description>
+        <terms:description xml:lang="en">This is a property to test an ObjectIntersectionOf. (Note that range values are added only for test purposes).</terms:description>
         <rdfs:label xml:lang="en">test ObjectIntersectionOf</rdfs:label>
     </owl:ObjectProperty>
     
@@ -365,8 +420,8 @@
         <rdfs:range>
             <rdfs:Datatype>
                 <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://www.w3.org/2001/XMLSchema#double"/>
                     <rdf:Description rdf:about="http://www.w3.org/2001/XMLSchema#integer"/>
-                    <rdf:Description rdf:about="http://www.w3.org/2001/XMLSchema#string"/>
                 </owl:unionOf>
             </rdfs:Datatype>
         </rdfs:range>
@@ -423,6 +478,16 @@
     
 
 
+    <!-- https://w3id.org/example#memberOfOtherDepartments -->
+
+    <owl:DatatypeProperty rdf:about="https://w3id.org/example#memberOfOtherDepartments">
+        <rdfs:domain rdf:resource="https://w3id.org/example#Professor"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
+        <rdfs:label xml:lang="en">member of other departments</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
     <!-- https://w3id.org/example#name -->
 
     <owl:DatatypeProperty rdf:about="https://w3id.org/example#name">
@@ -439,6 +504,20 @@
         <rdfs:domain rdf:resource="https://w3id.org/example#Person"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
         <rdfs:label xml:lang="en">nationality</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- https://w3id.org/example#numberOfProfessors -->
+
+    <owl:DatatypeProperty rdf:about="https://w3id.org/example#numberOfProfessors">
+        <rdfs:domain rdf:resource="https://w3id.org/example#Department"/>
+        <rdfs:range>
+            <rdfs:Datatype>
+                <owl:datatypeComplementOf rdf:resource="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"/>
+            </rdfs:Datatype>
+        </rdfs:range>
+        <rdfs:label xml:lang="en">number of professors</rdfs:label>
     </owl:DatatypeProperty>
     
 
@@ -511,6 +590,15 @@
     
 
 
+    <!-- https://w3id.org/example#Assignment -->
+
+    <owl:Class rdf:about="https://w3id.org/example#Assignment">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/example#EvaluationMethod"/>
+        <rdfs:label xml:lang="en">Assignment</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- https://w3id.org/example#BachelorProgram -->
 
     <owl:Class rdf:about="https://w3id.org/example#BachelorProgram">
@@ -528,15 +616,14 @@
     <owl:Class rdf:about="https://w3id.org/example#Course">
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="https://w3id.org/example#isTaughtBy"/>
-                <owl:someValuesFrom rdf:resource="https://w3id.org/example#Professor"/>
+                <owl:onProperty rdf:resource="https://w3id.org/example#hasStudyMaterial"/>
+                <owl:someValuesFrom rdf:resource="https://w3id.org/example#StudyMaterial"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="https://w3id.org/example#hasStudentEnrolled"/>
-                <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5</owl:minQualifiedCardinality>
-                <owl:onClass rdf:resource="https://w3id.org/example#Student"/>
+                <owl:onProperty rdf:resource="https://w3id.org/example#isTaughtBy"/>
+                <owl:someValuesFrom rdf:resource="https://w3id.org/example#Professor"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
@@ -552,11 +639,36 @@
     
 
 
+    <!-- https://w3id.org/example#Degree -->
+
+    <owl:Class rdf:about="https://w3id.org/example#Degree">
+        <rdfs:label xml:lang="en">Degree</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- https://w3id.org/example#Department -->
 
     <owl:Class rdf:about="https://w3id.org/example#Department">
         <terms:description xml:lang="en">Department of the University</terms:description>
         <rdfs:label xml:lang="en">Department</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/example#EvaluationMethod -->
+
+    <owl:Class rdf:about="https://w3id.org/example#EvaluationMethod">
+        <rdfs:label xml:lang="en">Evaluation Method</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://w3id.org/example#Exam -->
+
+    <owl:Class rdf:about="https://w3id.org/example#Exam">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/example#EvaluationMethod"/>
+        <rdfs:label xml:lang="en">Exam</rdfs:label>
     </owl:Class>
     
 
@@ -572,9 +684,24 @@
     
 
 
+    <!-- https://w3id.org/example#Organization -->
+
+    <owl:Class rdf:about="https://w3id.org/example#Organization">
+        <rdfs:label xml:lang="en">Organization</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- https://w3id.org/example#Person -->
 
     <owl:Class rdf:about="https://w3id.org/example#Person">
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://w3id.org/example#address"/>
+                <owl:maxQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">2</owl:maxQualifiedCardinality>
+                <owl:onDataRange rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <terms:description xml:lang="en">A human being regarded as an individual.</terms:description>
         <rdfs:label xml:lang="en">Person</rdfs:label>
     </owl:Class>
@@ -597,6 +724,19 @@
         <rdfs:subClassOf rdf:resource="https://w3id.org/example#Person"/>
         <rdfs:subClassOf>
             <owl:Restriction>
+                <owl:onProperty rdf:resource="https://w3id.org/example#hasDegree"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:oneOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="https://w3id.org/example/resource/Degree/MS"/>
+                            <rdf:Description rdf:about="https://w3id.org/example/resource/Degree/PhD"/>
+                        </owl:oneOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
                 <owl:onProperty rdf:resource="https://w3id.org/example#teachesCourse"/>
                 <owl:someValuesFrom rdf:resource="https://w3id.org/example#Course"/>
             </owl:Restriction>
@@ -615,9 +755,9 @@
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="https://w3id.org/example#belongsTo"/>
-                <owl:qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:qualifiedCardinality>
-                <owl:onClass rdf:resource="https://w3id.org/example#Department"/>
+                <owl:onProperty rdf:resource="https://w3id.org/example#researchField"/>
+                <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:minQualifiedCardinality>
+                <owl:onDataRange rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <owl:disjointWith rdf:resource="https://w3id.org/example#Student"/>
@@ -630,16 +770,25 @@
     <!-- https://w3id.org/example#ProfessorInArtificialIntelligence -->
 
     <owl:Class rdf:about="https://w3id.org/example#ProfessorInArtificialIntelligence">
+        <rdfs:subClassOf rdf:resource="https://w3id.org/example#Professor"/>
         <rdfs:subClassOf>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="https://w3id.org/example#Professor"/>
-                    <owl:Restriction>
-                        <owl:onProperty rdf:resource="https://w3id.org/example#belongsTo"/>
-                        <owl:hasValue rdf:resource="https://w3id.org/example/resource/Deparment/ArtificialIntelligenceDepartment"/>
-                    </owl:Restriction>
-                </owl:intersectionOf>
-            </owl:Class>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://w3id.org/example#belongsTo"/>
+                <owl:hasValue rdf:resource="https://w3id.org/example/resource/Department/ArtificialIntelligenceDepartment"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://w3id.org/example#memberOfOtherDepartments"/>
+                <owl:someValuesFrom>
+                    <rdfs:Datatype>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"/>
+                            <rdf:Description rdf:about="http://www.w3.org/2001/XMLSchema#nonPositiveInteger"/>
+                        </owl:intersectionOf>
+                    </rdfs:Datatype>
+                </owl:someValuesFrom>
+            </owl:Restriction>
         </rdfs:subClassOf>
         <terms:description xml:lang="en">Professor who belongs to the Artificial Intelligence Deparment</terms:description>
         <rdfs:label xml:lang="en">Professor in Artificial Intelligence</rdfs:label>
@@ -708,6 +857,14 @@
     
 
 
+    <!-- https://w3id.org/example#StudyMaterial -->
+
+    <owl:Class rdf:about="https://w3id.org/example#StudyMaterial">
+        <rdfs:label xml:lang="en">Study Material</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- https://w3id.org/example#StudyProgram -->
 
     <owl:Class rdf:about="https://w3id.org/example#StudyProgram">
@@ -715,6 +872,12 @@
             <owl:Restriction>
                 <owl:onProperty rdf:resource="https://w3id.org/example#hasCourse"/>
                 <owl:someValuesFrom rdf:resource="https://w3id.org/example#Course"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://w3id.org/example#studyProgramName"/>
+                <owl:allValuesFrom rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <terms:description xml:lang="en">Study program which the course is part of.</terms:description>
@@ -728,7 +891,7 @@
     <owl:Class rdf:about="https://w3id.org/example#University">
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="https://w3id.org/example#hasDeparment"/>
+                <owl:onProperty rdf:resource="https://w3id.org/example#hasDepartment"/>
                 <owl:someValuesFrom rdf:resource="https://w3id.org/example#Department"/>
             </owl:Restriction>
         </rdfs:subClassOf>
@@ -750,6 +913,13 @@
                 <owl:someValuesFrom rdf:resource="https://w3id.org/example#StudyProgram"/>
             </owl:Restriction>
         </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://w3id.org/example#universityName"/>
+                <owl:qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</owl:qualifiedCardinality>
+                <owl:onDataRange rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
         <terms:description xml:lang="en">A high-level educational institution in which students study for degrees and academic research is done.</terms:description>
         <rdfs:label xml:lang="en">University</rdfs:label>
     </owl:Class>
@@ -767,11 +937,30 @@
     
 
 
-    <!-- https://w3id.org/example/resource/Deparment/ArtificialIntelligenceDepartment -->
+    <!-- https://w3id.org/example/resource/Degree/MS -->
 
-    <owl:NamedIndividual rdf:about="https://w3id.org/example/resource/Deparment/ArtificialIntelligenceDepartment">
+    <owl:NamedIndividual rdf:about="https://w3id.org/example/resource/Degree/MS">
+        <rdf:type rdf:resource="https://w3id.org/example#Degree"/>
+        <rdfs:label xml:lang="en">Master degree</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- https://w3id.org/example/resource/Degree/PhD -->
+
+    <owl:NamedIndividual rdf:about="https://w3id.org/example/resource/Degree/PhD">
+        <rdf:type rdf:resource="https://w3id.org/example#Degree"/>
+        <rdfs:label xml:lang="en">PhD degree</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- https://w3id.org/example/resource/Department/ArtificialIntelligenceDepartment -->
+
+    <owl:NamedIndividual rdf:about="https://w3id.org/example/resource/Department/ArtificialIntelligenceDepartment">
         <rdf:type rdf:resource="https://w3id.org/example#Department"/>
-        <departmentName xml:lang="en">Artificial Intelligence</departmentName>
+        <departmentName>Artificial Intelligence</departmentName>
+        <rdfs:label xml:lang="en">Department of Artificial Intelligence</rdfs:label>
     </owl:NamedIndividual>
 </rdf:RDF>
 

--- a/examples/restrictions/example.owl
+++ b/examples/restrictions/example.owl
@@ -293,24 +293,6 @@
     
 
 
-    <!-- https://w3id.org/example#testObjectIntersectionOf -->
-
-    <owl:ObjectProperty rdf:about="https://w3id.org/example#testObjectIntersectionOf">
-        <rdfs:domain rdf:resource="https://w3id.org/example#Person"/>
-        <rdfs:range>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="https://w3id.org/example#StudentRecord"/>
-                    <rdf:Description rdf:about="https://w3id.org/example#StudyProgram"/>
-                </owl:intersectionOf>
-            </owl:Class>
-        </rdfs:range>
-        <terms:description xml:lang="en">This is a property to test an ObjectIntersectionOf. (Note that range values are added only for test purposes).</terms:description>
-        <rdfs:label xml:lang="en">test ObjectIntersectionOf</rdfs:label>
-    </owl:ObjectProperty>
-    
-
-
     <!-- https://w3id.org/example#testObjectUnionOf -->
 
     <owl:ObjectProperty rdf:about="https://w3id.org/example#testObjectUnionOf">

--- a/examples/restrictions/readme.md
+++ b/examples/restrictions/readme.md
@@ -1,0 +1,5 @@
+## Restrictions example ontology
+
+This restrictions example ontology illustrates several ontology constructs to show how to represent them in the OAS.
+
+Note that this example was tested on macOS (hence the file path) and the working directory is assumed to be the above the "examples" folder

--- a/examples/saref4city/config.yaml
+++ b/examples/saref4city/config.yaml
@@ -15,8 +15,8 @@ openapi:
     url: https://w3id.org/def/saref4city
 
 firebase:
-  key: 
-  
+  key:
+
 endpoint:
   url: http://endpoint.mint.isi.edu/example
   prefix: https://w3id.org/okn/i/example
@@ -28,4 +28,3 @@ enable_delete_paths: false
 enable_put_paths: false
 
 follow_references: true
-

--- a/src/main/java/edu/isi/oba/Mapper.java
+++ b/src/main/java/edu/isi/oba/Mapper.java
@@ -4,7 +4,6 @@ import edu.isi.oba.config.YamlConfig;
 import io.swagger.v3.oas.models.Paths;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.media.StringSchema;
-import io.swagger.v3.oas.models.media.XML;
 import org.semanticweb.owlapi.apibinding.OWLManager;
 import org.semanticweb.owlapi.model.*;
 

--- a/src/main/java/edu/isi/oba/MapperDataProperty.java
+++ b/src/main/java/edu/isi/oba/MapperDataProperty.java
@@ -28,8 +28,8 @@ class MapperDataProperty {
     this.dataTypes.put("boolean", "boolean");
     this.dataTypes.put("byte", "integer");
     this.dataTypes.put("date", "string");
-    this.dataTypes.put("dateTime", "string");
-    this.dataTypes.put("dateTimeStamp", "string");
+    this.dataTypes.put("dateTime", "dateTime");
+    this.dataTypes.put("dateTimeStamp", "dateTime");
     this.dataTypes.put("decimal", "number");
     this.dataTypes.put("double", "number");
     this.dataTypes.put("duration", "string");
@@ -69,6 +69,7 @@ class MapperDataProperty {
   private static final String NUMBER_TYPE = "number";
   private static final String INTEGER_TYPE = "integer";
   private static final String BOOLEAN_TYPE = "boolean";
+  private static final String DATETIME_TYPE = "dateTime";
 
   final String name;
   final String description;
@@ -115,7 +116,9 @@ class MapperDataProperty {
         return (array) ? arraySchema(new IntegerSchema(), nullable) : new IntegerSchema().nullable(nullable).description(description);
       case BOOLEAN_TYPE:
         return (array) ? arraySchema(new BooleanSchema(), nullable) : new BooleanSchema().nullable(nullable).description(description);
-     default:
+      case DATETIME_TYPE:
+          return (array) ? arraySchema(new DateTimeSchema() , nullable) : new DateTimeSchema().nullable(nullable).description(description);
+      default:
         logger.warning("datatype mapping failed " + this.type.get(0));
         return (array) ? arraySchema(new Schema(), nullable) : new Schema().nullable(nullable).description(description);
     }

--- a/src/main/java/edu/isi/oba/MapperDataProperty.java
+++ b/src/main/java/edu/isi/oba/MapperDataProperty.java
@@ -4,6 +4,8 @@ import io.swagger.v3.oas.models.media.*;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+
 import static edu.isi.oba.Oba.logger;
 
 class MapperDataProperty {
@@ -58,6 +60,7 @@ class MapperDataProperty {
     this.dataTypes.put("unsignedLong", "integer");
     this.dataTypes.put("unsignedShort", "integer");
     this.dataTypes.put("langString", "string");
+    this.dataTypes.put("Literal", "string");
 
   }
 
@@ -77,9 +80,11 @@ class MapperDataProperty {
   private Boolean array;
   private Boolean nullable;
   final Boolean isFunctional;
+  private Map<String,String> restrictions;
+  private List<String> valuesFromDataRestrictions_ranges;
 
 
-  public MapperDataProperty(String name, String description, Boolean isFunctional, List<String> type, Boolean array, Boolean nullable) {
+  public MapperDataProperty(String name, String description, Boolean isFunctional,Map<String,String> restrictions,List<String> valuesFromDataRestrictions_ranges, List<String> type, Boolean array, Boolean nullable) {
     this.dataTypes = new HashMap<>();
     this.setDataTypes();
     this.name = name;
@@ -88,19 +93,17 @@ class MapperDataProperty {
     this.array = array;
     this.nullable = nullable;
     this.isFunctional=isFunctional;
+    this.restrictions=restrictions;
+    this.valuesFromDataRestrictions_ranges=valuesFromDataRestrictions_ranges;
   }
 
   public Schema getSchemaByDataProperty(){
-    //TODO: Assumption: only one type
-    //if (this.name.equalsIgnoreCase("hasMaximumAcceptedValue")){
-    //  System.out.println("a");
-    ////}
-
+	  
     if (this.type.size() == 0) {
       return (array) ? arraySchema(new StringSchema(), nullable) : new StringSchema().nullable(nullable).description(description);
     }
     else if (this.type.size() > 1){
-      return (array) ? arraySchema(new Schema(), nullable) : new Schema().nullable(nullable).description(description);
+    	return (array) ? composedSchema(this.type, nullable) : new Schema().nullable(nullable).description(description);
     }
 
     String schemaType = getDataType(this.type.get(0));
@@ -124,61 +127,128 @@ class MapperDataProperty {
     }
   }
 
-  //Not used
-//  private Schema getObjectPropertiesByRef(String ref, boolean array, boolean nullable){
-//    Schema object = new ObjectSchema();
-//    object.set$ref(ref);
-//
-//    if (array) {
-//      ArraySchema objects = new ArraySchema();
-//      objects.setNullable(nullable);
-//      objects.setItems(object);
-//      return objects;
-//    }
-//    else {
-//      return object;
-//    }
-//
-//
-//  }
-//  not used
-//  private Schema getComposedSchemaObject(List<String> refs, boolean array, boolean nullable){
-//    Schema object = new ObjectSchema();
-//    object.setType("object");
-//
-//    if (array) {
-//      ArraySchema objects = new ArraySchema();
-//      objects.setNullable(nullable);
-//      objects.setItems(object);
-//      return objects;
-//    }
-//    else {
-//      return object;
-//    }
-//
-//        /*ComposedSchema composedSchema = new ComposedSchema();
-//        List<Schema> items = new ArrayList<>();
-//        for (String ref : refs){
-//            Schema item = getObjectPropertiesByRef(ref, array, nullable);
-//            items.add(item);
-//        }
-//        composedSchema.setAnyOf(items);
-//        return composedSchema;
-//        */
-//
-//  }
+  /**
+   * Generate a range of multiple values depending on the range axiom
+   *
+   * @return An ArraySchema: including a composedSchema with a list of items for anyOf, allOf restrictions.
+   */ 
+  private ArraySchema composedSchema(List<String> base, boolean nullable){
+	  ArraySchema array = new ArraySchema();
+	  Schema schema ;
+	  ComposedSchema composedSchema = new ComposedSchema() ;
+	  array.setDescription(description);
+	  array.setNullable(nullable);  
+	  // Operations for managing boolean combinations 
+	  for (String restriction:  restrictions.keySet()) { 
+		  String value = restrictions.get(restriction); 	  
+		  for (String item:base) {		  
+			  switch (getDataType(item)) {
+			  case STRING_TYPE:
+				  schema = new StringSchema();
+				  if (item.equals("anyURI"))
+					  schema.format("uri");
+				  else if (item.equals("byte"))
+					  schema.format("byte");
+				  break ;
+			  case NUMBER_TYPE:
+				  schema = new NumberSchema();
+				  if (item.equals("float"))
+					  schema.format("float");
+				  else if (item.equals("double"))
+					  schema.format("double");
+				  break ;
+			  case INTEGER_TYPE:
+				  schema = new IntegerSchema();
+				  if (item.equals("long"))
+					  schema.format("int64");
+				  break ;
+			  case BOOLEAN_TYPE:
+				  schema = new BooleanSchema();
+				  break ;
+			  case DATETIME_TYPE:
+				  schema = new DateTimeSchema();
+				  break ;	       
+			  default:
+				  logger.warning("datatype mapping failed " + this.type.get(0));
+				  schema = new Schema();	  	
+			  }
+			  
+			  switch (restriction) {
+			  case "unionOf":
+				  if (value=="someValuesFrom")
+		        		nullable=false;	
+				  composedSchema.addAnyOfItem(schema); 
+				  break;
+			  case "intersectionOf":
+				  if (value=="someValuesFrom")
+		        		nullable=false;	
+				  composedSchema.addAllOfItem(schema);
+				  break;
+			  default:
+				  break;
+			  }
+		  }
+	  }
+	  array.setItems(composedSchema);  	 
 
-
-
+	  if (isFunctional)
+		  array.setMaxItems(1);
+	  array.setNullable(nullable);	     
+	  return array ;
+  }
 
   private ArraySchema arraySchema(Schema base, boolean nullable) {
-    ArraySchema array = new ArraySchema();
-    array.setDescription(description);
-    array.setNullable(nullable);
-    array.setItems(base);
-    if (isFunctional)
-        array.setMaxItems(1);
-    return array;
+	  ArraySchema array = new ArraySchema();
+	  array.setDescription(description);
+
+	  if (isFunctional)
+		  array.setMaxItems(1);
+
+	  for (String restriction:  restrictions.keySet()) { 
+		  String value = restrictions.get(restriction);
+		  switch (restriction) {
+		  case "dataHasValue":      		
+			  base.setDefault(value);
+			  break;
+		  case "maxCardinality":
+			  base.setMaxItems(Integer.parseInt(value));
+			  break ;
+		  case "minCardinality":	
+			  base.setMinItems(Integer.parseInt(value));
+			  break ;
+		  case "exactCardinality":
+			  base.setMaxItems(Integer.parseInt(value));
+			  base.setMinItems(Integer.parseInt(value));
+			  break ;
+		  case "someValuesFrom": 
+			  nullable=false;
+			  break ;
+		  case "allValuesFrom":      	 
+			  //nothing to do
+			  break ; 		   
+		  case "oneOf":   
+			  if (value=="someValuesFrom")
+				  nullable=false;	
+			  for (String rangeValue:valuesFromDataRestrictions_ranges)
+				  base.addEnumItemObject(rangeValue);
+			  break;			 
+		  case "complementOf":  
+			  Schema schema = new Schema();
+			  Schema complementOf = new Schema();
+			  complementOf.setType(getDataType(type.get(0)));
+			  complementOf.setFormat(type.get(0));
+			  schema.setNot(complementOf);
+			  array.setNullable(nullable);
+			  array.setItems(schema);
+			  return array;
+		  default:
+		  } 
+	  } 
+
+	  array.setNullable(nullable);
+	  array.setItems(base);
+
+	  return array;
   }
 
 }

--- a/src/main/java/edu/isi/oba/MapperObjectProperty.java
+++ b/src/main/java/edu/isi/oba/MapperObjectProperty.java
@@ -2,7 +2,10 @@ package edu.isi.oba;
 
 import io.swagger.v3.oas.models.media.*;
 
+import static edu.isi.oba.Oba.logger;
+
 import java.util.List;
+import java.util.Map;
 
 class MapperObjectProperty {
   final String name;
@@ -11,23 +14,27 @@ class MapperObjectProperty {
   private Boolean array;
   private Boolean nullable;
   final Boolean isFunctional;
+  
+  final Map<String,String>  restrictions;
 
-  public MapperObjectProperty(String name, String description, Boolean isFunctional, List<String> ref) {
+  public MapperObjectProperty(String name, String description, Boolean isFunctional, Map<String,String> restrictions, List<String> ref) {
     this.name = name;
     this.description = description;
     this.ref = ref;
     this.array = true;
     this.nullable = true;
     this.isFunctional=isFunctional;
+    this.restrictions = restrictions;
   }
 
-  public MapperObjectProperty(String name, String description,  Boolean isFunctional, List<String> ref, Boolean array, Boolean nullable) {
+  public MapperObjectProperty(String name, String description,  Boolean isFunctional, Map<String,String> restrictions, List<String> ref, Boolean array, Boolean nullable) {
     this.name = name;
     this.description = description;
     this.ref = ref;
     this.array = array;
     this.nullable = nullable;
     this.isFunctional=isFunctional;
+    this.restrictions = restrictions;
   }
 
   public Schema getSchemaByObjectProperty(){
@@ -51,10 +58,37 @@ class MapperObjectProperty {
     if (array) {
       ArraySchema objects = new ArraySchema();
       objects.setDescription(description);
-      objects.setNullable(nullable);
-      objects.setItems(object);
       if (isFunctional)
           objects.setMaxItems(1);
+      
+      for (String restriction:  restrictions.keySet()) { 
+    	  String value = restrictions.get(restriction);
+      switch (restriction) {
+      case "maxCardinality":
+    	objects.setMaxItems(Integer.parseInt(value));
+      	break ;
+      case "minCardinality":	
+    	  objects.setMinItems(Integer.parseInt(value));
+      	break ;
+      case "exactCardinality":
+    	  objects.setMaxItems(Integer.parseInt(value));
+    	  objects.setMinItems(Integer.parseInt(value));
+      	break ;
+      case "someValuesFrom": 
+    	  nullable=false;
+      	break ;
+      case "allValuesFrom":      	  
+    	  //nothing to do in the Schema
+      	break ;   
+      case "objectHasValue":
+    	  break ; 
+      default:
+    	  break ; 
+    	} 
+      }     
+      
+      objects.setNullable(nullable);
+      objects.setItems(object);      
       return objects;
     }
     else {
@@ -65,17 +99,54 @@ class MapperObjectProperty {
   }
   private Schema getComposedSchemaObject(List<String> refs, boolean array, boolean nullable){
     Schema object = new ObjectSchema();
+    ComposedSchema composedSchema = new ComposedSchema() ;
+    
     object.setType("object");
     object.setDescription(description);
 
     if (array) {
-      ArraySchema objects = new ArraySchema();
-      objects.setDescription(description);
-      objects.setNullable(nullable);
-      objects.setItems(object);
-      if (isFunctional)
-          objects.setMaxItems(1);
-      return objects;
+    	ArraySchema objects = new ArraySchema();
+    	objects.setDescription(description);
+    	objects.setNullable(nullable);
+    	if (isFunctional)
+    		objects.setMaxItems(1);
+
+    	for (String restriction:  restrictions.keySet()) { 
+    		String value = restrictions.get(restriction); 
+
+    		for (String item:refs) {
+    			Schema objectRange = new ObjectSchema();
+    			objectRange.setType("object");
+    			objectRange.set$ref(item);
+    			switch (restriction) {
+    			case "unionOf":
+    				if (value=="someValuesFrom")
+    					nullable=false;	
+    				composedSchema.addAnyOfItem(objectRange);
+    				objects.setItems(composedSchema);
+    				break ;
+    			case "intersectionOf":
+    				if (value=="someValuesFrom")
+    					nullable=false;	
+    				composedSchema.addAllOfItem(objectRange);
+    				objects.setItems(composedSchema);
+    				break ;
+    			case "someValuesFrom": 
+    				nullable=false;
+    				break;
+    			case "allValuesFrom":      	  
+    				//nothing to do in the Schema
+    				break ;  
+    			default:
+    				//if the property range is complex it will be omitted   
+    				logger.warning("omitted complex restriction");	 
+    				objects.setItems(object); 		          
+    			}             
+    		}
+    	}     
+    	if (refs.size() == 0)
+    		objects.setItems(object);
+    	return objects;
     }
     else {
       return object;

--- a/src/main/java/edu/isi/oba/MapperSchema.java
+++ b/src/main/java/edu/isi/oba/MapperSchema.java
@@ -2,6 +2,7 @@ package edu.isi.oba;
 
 
 import io.swagger.v3.oas.models.examples.Example;
+import io.swagger.v3.oas.models.media.ObjectSchema;
 import io.swagger.v3.oas.models.media.Schema;
 import org.semanticweb.owlapi.apibinding.OWLManager;
 import org.semanticweb.owlapi.model.*;
@@ -262,11 +263,9 @@ class MapperSchema {
 
         				String propertyURI = odp.getIRI().toString();
         				propertyNameURI.put(propertyURI, propertyName);
-
         				List<String> propertyRanges = getCodeGenTypesByRangeObject(ranges, odp, owlThing, follow_references);
 
         				Map<String,String> restrictionValues = new HashMap<String, String>() ;
-        				String restrictions ="";
         				for (OWLOntology ontology : ontologies) {
         					RestrictionVisitor restrictionVisitor = new RestrictionVisitor(cls,ontology,owlThing,propertyName);
         					for (OWLObjectPropertyRangeAxiom propertyRangeAxiom : ranges) {
@@ -279,8 +278,8 @@ class MapperSchema {
         							restrictionValues=restrictionsValuesFromClass.get(j);
         						}
         					}
-        					if (restrictionsValuesFromClass.isEmpty())
-        						propertyRanges.clear();
+        					if (restrictionsValuesFromClass.isEmpty() && propertyRanges.size()>1)
+                        		propertyRanges.clear();
         				}
 
         				String propertyDescription = ObaUtils.getDescription(odp, ontology_cls);
@@ -387,6 +386,7 @@ class MapperSchema {
     			} else {
 
     			for (int i = 0; i < propertiesFromObjectRestrictions.size(); i++) {
+    				MapperObjectProperty mapperObjectProperty;
     				OWLObjectProperty OP = propertiesFromObjectRestrictions.get(i);
     				String propertyDescription = ObaUtils.getDescription(OP, ontology_cls);
     				if (propertiesFromObjectRestrictions_ranges.size() != 0) {
@@ -394,7 +394,10 @@ class MapperSchema {
     					for (String j :  restrictionsValuesFromClass.keySet()) {
     						Map<String,String> restrictionValues=restrictionsValuesFromClass.get(j);
     						if (j==sfp.getShortForm(OP.getIRI())) {
-    							MapperObjectProperty mapperObjectProperty = new MapperObjectProperty(sfp.getShortForm(OP.getIRI()), propertyDescription, false, restrictionValues, rangesOP);
+    							if (rangesOP.get(0)=="defaultValue")
+    								mapperObjectProperty = new MapperObjectProperty(sfp.getShortForm(OP.getIRI()), propertyDescription, false, restrictionValues, rangesOP, false, true);
+    							else
+    								mapperObjectProperty = new MapperObjectProperty(sfp.getShortForm(OP.getIRI()), propertyDescription, false, restrictionValues, rangesOP);
     							try {
     								this.properties.put(mapperObjectProperty.name, mapperObjectProperty.getSchemaByObjectProperty());
     							} catch (Exception e) {

--- a/src/main/java/edu/isi/oba/Oba.java
+++ b/src/main/java/edu/isi/oba/Oba.java
@@ -26,8 +26,8 @@ class Oba {
     /*
     TODO: we are supporting one language. Issue #42
     */
-
-    InputStream stream = Oba.class.getClassLoader().getResourceAsStream("logging.properties");
+	
+   InputStream stream = Oba.class.getClassLoader().getResourceAsStream("logging.properties");
     try {
       LogManager.getLogManager().readConfiguration(stream);
       logger = Logger.getLogger(Oba.class.getName());
@@ -39,7 +39,7 @@ class Oba {
     LANGUAGE selected_language = LANGUAGE.PYTHON_FLASK;
     logger.setLevel(Level.FINE);
     logger.addHandler(new ConsoleHandler());
-
+	  
     //parse command line
     String config_yaml = ObaUtils.get_config_yaml(args);
     //read the config yaml from command line
@@ -81,6 +81,8 @@ class Oba {
     copy_custom_queries(custom_queries_dir, destination_dir);
   }
 
+ 
+  
   private static void generate_context(YamlConfig config_data, String destination_dir) {
     List<String> ontologies = config_data.getOntologies();
     JSONObject context_json_object = null;

--- a/src/main/java/edu/isi/oba/RestrictionVisitor.java
+++ b/src/main/java/edu/isi/oba/RestrictionVisitor.java
@@ -1,0 +1,333 @@
+package edu.isi.oba;
+
+import static edu.isi.oba.Oba.logger;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.semanticweb.owlapi.model.*;
+import org.semanticweb.owlapi.util.IRIShortFormProvider;
+import org.semanticweb.owlapi.util.SimpleIRIShortFormProvider;
+
+/**
+ * Visitor interface to inspect Class Restrictions
+ * @param class Represents the OWLClass
+ * @param onto  Represents the Ontology that contains the Class
+ * @param owlThing
+ * @param propertyName Represents the name of a property that will be analyzed when this property has a restriction
+ * 		   (e.g. it may be invoked from the getObjectProperties method of the MapperSchema). 
+ * It defines values for the following global variables: 
+ * 
+ * - propertiesFromObjectRestrictions -> contains all the restricted OWLObjectProperties  
+ * - propertiesFromObjectRestrictions_ranges -> contains the Ranges of each Class Object Restriction
+ * - restrictionsValuesFromClass -> contains the restriction names of each Class Object Restriction and its values 
+ *   e.g. [exactCardinality 5].  However, for restrictions that does not have a value a blank string is added, 
+ *   e.g. [someValuesFrom ""]. It is worth noting that when an existential or universal restriction contains other 
+ *   restriction it will be from this map and the nested restriction will be added including as its value the 
+ *   restriction that contain the nested restriction e.g. [unionOf someValuesFrom]. The restrictionsValuesFromClass 
+ *   will be used to map the ObjectProperties its the corresponding Schema.
+ *                                                       
+ */
+
+public class RestrictionVisitor implements OWLObjectVisitor {
+	private final IRIShortFormProvider sfp = new SimpleIRIShortFormProvider();
+	private final Set<OWLClass> processedClasses;
+	private final OWLClass cls;
+	private final OWLOntology onto;
+	String property_name;
+	OWLClass owlThing; 
+	
+	public Map<String, Map<String,String>> restrictionsValuesFromClass;
+	
+	public List<OWLObjectProperty> propertiesFromObjectRestrictions;
+	public Map<String, List<String>> propertiesFromObjectRestrictions_ranges;
+
+
+
+	RestrictionVisitor(OWLClass clas, OWLOntology onto, OWLClass owlThing, String propertyName ) {
+		processedClasses = new HashSet<OWLClass>();
+		this.cls=clas;
+		this.onto=onto;
+		this.property_name=propertyName;           
+		this.owlThing=owlThing;   
+		this.propertiesFromObjectRestrictions_ranges= new HashMap<>();
+		this.propertiesFromObjectRestrictions = new ArrayList<>();
+		
+		this.restrictionsValuesFromClass = new HashMap<>();
+
+	}
+
+	@Override
+	public void visit(OWLClass ce) {
+		if (!processedClasses.contains(ce)) {
+			// If we are processing inherited restrictions then we recursively visit named supers. 
+			processedClasses.add(ce);
+			for (OWLSubClassOfAxiom ax : onto.getSubClassAxiomsForSubClass(ce)) {
+				ax.getSuperClass().accept(this);                        
+			}               
+		}
+	}
+
+	@Override
+	public void visit(OWLObjectSomeValuesFrom ce) {
+		// This method gets called when a class expression is an existential
+		// (someValuesFrom) restriction and it asks us to visit it
+		Map<String, String> restrictionsValues = new HashMap<String, String>();
+		logger.info("Analyzing restrictions of Class: " + this.cls+ " with axiom: "+ce);
+		
+		for(OWLObjectProperty property:ce.getObjectPropertiesInSignature()) {        		   
+			propertiesFromObjectRestrictions.add(property);
+			property_name = sfp.getShortForm(property.getIRI());        		
+		}
+		if (ce.getFiller() instanceof OWLObjectUnionOf || ce.getFiller() instanceof OWLObjectIntersectionOf) {
+			
+			restrictionsValues.put("someValuesFrom", "");			
+			restrictionsValuesFromClass.put(property_name, restrictionsValues);
+			ce.getFiller().accept(this);
+		} else {       	   
+			List<String> ranges = new ArrayList<String>();
+			ranges.add(sfp.getShortForm(ce.getFiller().asOWLClass().getIRI()));
+			if (ce.getFiller().asOWLClass().equals(owlThing)) {
+				logger.info("Ignoring owl:Thing range" + property_name);                       
+			}
+			else
+				propertiesFromObjectRestrictions_ranges.put(property_name,ranges);        		  
+			
+			restrictionsValues.put("someValuesFrom", "");			
+			restrictionsValuesFromClass.put(property_name, restrictionsValues);
+		}
+	}
+	@Override
+	public void visit(OWLObjectAllValuesFrom ce) {
+		// This method gets called when a class expression is a universal
+		// (allValuesFrom) restriction and it asks us to visit it
+		logger.info("Analyzing restrictions of Class: " + this.cls+ " with axiom: "+ce);
+		Map<String, String> restrictionsValues = new HashMap<String, String>();
+		for(OWLObjectProperty property:ce.getObjectPropertiesInSignature()) {        		   
+			propertiesFromObjectRestrictions.add(property);
+			property_name = sfp.getShortForm(property.getIRI()); 		
+		}
+		if (ce.getFiller() instanceof OWLObjectUnionOf || ce.getFiller() instanceof OWLObjectIntersectionOf) {
+			ce.getFiller().accept(this);
+		} else {       	   
+			List<String> ranges = new ArrayList<String>();
+			ranges.add(sfp.getShortForm(ce.getFiller().asOWLClass().getIRI()));
+			if (ce.getFiller().asOWLClass().equals(owlThing)) {
+				logger.info("Ignoring owl:Thing range" + property_name);                       
+			}
+			else
+				propertiesFromObjectRestrictions_ranges.put(property_name,ranges);        		  
+
+			restrictionsValues.put("allValuesFrom", "");			
+			restrictionsValuesFromClass.put(property_name, restrictionsValues);
+		}
+	}
+	
+	
+	@Override
+	public void visit( OWLObjectUnionOf ce ) {		 							    	
+		logger.info("Analyzing restrictions of Class: " + this.cls+ " with axiom: "+ce);
+		Set<OWLClassExpression> ranges = ce.getOperands();
+		Set<OWLObjectProperty> properties = ce.getObjectPropertiesInSignature();
+		setBooleanCombinationProperties(ranges,  properties, "unionOf");
+	}
+	@Override
+	public void visit( OWLObjectIntersectionOf ce ) {		 							    	
+		logger.info("Analyzing restrictions of Class: " + this.cls+ " with axiom: "+ce);  
+		Set<OWLClassExpression> ranges = ce.getOperands();
+		Set<OWLObjectProperty> properties = ce.getObjectPropertiesInSignature();
+		setBooleanCombinationProperties(ranges, properties, "intersectionOf");
+	}
+
+	@Override
+	public void visit( OWLObjectMinCardinality ce ) {
+		logger.info("Analyzing restrictions of Class: " + this.cls+ " with axiom: "+ce);
+		setPropertiesWithCardinality(ce, "minCardinality");
+		
+	}
+	@Override
+	public void visit( OWLObjectMaxCardinality ce ) {
+		logger.info("Analyzing restrictions of Class: " + this.cls+ " with axiom: "+ce);	 
+		setPropertiesWithCardinality(ce,"maxCardinality")	;
+	} 
+	@Override
+	public void visit( OWLObjectExactCardinality ce ) {
+		logger.info("Analyzing restrictions of Class: " + this.cls+ " with axiom: "+ce);
+		setPropertiesWithCardinality(ce,  "exactCardinality")	;
+	}
+	
+	@Override
+	public void visit( OWLObjectComplementOf ce ) {
+		logger.info("Analyzing restrictions of Class: " + this.cls+ " with axiom: "+ce);
+		Map<String, String> restrictionsValues = new HashMap<String, String>();
+		String complementName = this.sfp.getShortForm(ce.getOperand().asOWLClass().getIRI());					
+		restrictionsValues.put("complementOf", complementName );	
+		restrictionsValuesFromClass.put("complementOf", restrictionsValues);
+ 	}
+	
+	@Override
+	public void visit(OWLObjectHasValue ce) {
+		logger.info("Analyzing restrictions of Class: " + this.cls+ " with axiom: "+ce);
+		Map<String, String> restrictionsValues = new HashMap<String, String>();
+		for(OWLObjectProperty property:ce.getObjectPropertiesInSignature()) {
+			property_name = sfp.getShortForm(property.getIRI());		
+			restrictionsValues.put("objectHasValue",ce.getValue().toString());	
+			restrictionsValuesFromClass.put(property_name, restrictionsValues);
+		}
+	}
+	
+	
+	// TODO: add validation for all the dataProperties e.g. OWLDataAllValuesFrom
+	@Override
+	public void visit( OWLDataAllValuesFrom ce ) {
+
+
+	}
+	@Override
+	public void visit( OWLDataSomeValuesFrom ce ) {
+
+	}
+	
+	@Override
+	public void visit( OWLDataUnionOf ce ) {
+
+	}
+	
+	@Override
+	public void visit( OWLDataIntersectionOf ce ) {
+
+	}
+	
+	@Override
+	public void visit( OWLDataMinCardinality ce ) {
+		
+
+	}
+	
+	@Override
+	public void visit( OWLDataMaxCardinality ce ) {
+		 			
+	} 
+	
+	@Override
+	public void visit( OWLDataExactCardinality ce ) {
+		
+
+	}
+	
+	@Override
+	public void visit( OWLDataHasValue ce ) {
+		logger.info("Analyzing restrictions of Class: " + this.cls+ " with axiom: "+ce);
+		Map<String, String> restrictionsValues = new HashMap<String, String>();		
+		for(OWLObjectProperty property:ce.getObjectPropertiesInSignature()) {
+			property_name = sfp.getShortForm(property.getIRI());
+			OWLLiteral value=ce.getValue();
+			restrictionsValues.put("dataHasValue",value.getLiteral());	
+			restrictionsValuesFromClass.put(property_name, restrictionsValues);
+		}
+	}
+
+	 /**
+     * Method that given a class expression of any cardinality type will set it and its value.
+     * @param ce object cardinality value e.g. OWLObjectExactCardinality
+     * @param retriction string value of restriction e.g. "exactCardinality"
+     */
+	public void setPropertiesWithCardinality(OWLObjectCardinalityRestriction ce, String restriction) {
+		String property_name="";
+		List<String> ranges = new ArrayList<String>();
+		Map<String, String> restrictionsValues = new HashMap<String, String>();
+		for(OWLObjectProperty property:ce.getObjectPropertiesInSignature()) {
+			propertiesFromObjectRestrictions.add(property);
+			property_name = sfp.getShortForm(property.getIRI());    	
+			ranges.add(sfp.getShortForm(ce.getFiller().asOWLClass().getIRI()));
+			propertiesFromObjectRestrictions_ranges.put(property_name,ranges);
+		}	    
+		this.property_name =  property_name;
+		
+		restrictionsValues.put(restriction, Integer.toString(ce.getCardinality()));			
+		restrictionsValuesFromClass.put(property_name, restrictionsValues);
+	}
+	
+	 /**
+     * Method that given a set of ranges and properties will set them according to the boolean restriction .
+     * @param ranges a set of class ranges that compose the boolean restriction
+     * @param properties object properties expression that have the boolean restriction 
+     * @param restriction string value of restriction e.g. "unionOf"
+     */
+	public void setBooleanCombinationProperties( Set<OWLClassExpression> ranges, Set<OWLObjectProperty> properties, String restriction) {
+		Boolean inspect=true;
+		Map<String, String> restrictionsValues = new HashMap<String, String>();
+		for (OWLClassExpression value :ranges) {
+			//if operands from boolean restriction contain complex combinations the restriction on this property
+			// will be ignored                   		 
+			if (value instanceof OWLObjectIntersectionOf || value instanceof OWLObjectComplementOf || value instanceof OWLObjectSomeValuesFrom || value instanceof OWLObjectAllValuesFrom 
+					|| value instanceof OWLObjectHasValue) {                    			                    		        				
+				logger.warning("Ignoring complex range restriction of property "+ property_name);				
+				if (property_name!="") {
+					propertiesFromObjectRestrictions.remove(property_name);	
+					restrictionsValuesFromClass.remove(property_name);
+				}
+				inspect=false;
+			} 
+		}
+		// if there are not complex range restrictions inspect ce
+		if (inspect) {
+			//if the expression ce is not part of a composed expression (existencial or universal)
+			if (property_name=="") { 
+				for(OWLObjectProperty property:properties) {
+					propertiesFromObjectRestrictions.add(property);
+					property_name = sfp.getShortForm(property.getIRI());
+					
+					
+					restrictionsValues.put(restriction, "");			
+					restrictionsValuesFromClass.put(property_name, restrictionsValues);
+				}
+			} else { 
+				List<String> rangeList = new ArrayList<String>();
+				for (OWLClassExpression range:ranges) {  
+					rangeList.add(sfp.getShortForm(range.asOWLClass().getIRI()));
+					if (range.asOWLClass().equals(owlThing)) {
+						logger.info("Ignoring owl:Thing range" + property_name);                       
+					}
+					else {						
+						propertiesFromObjectRestrictions_ranges.put(property_name,rangeList);							
+					} 					
+				}
+				
+				if (restrictionsValuesFromClass.size()!=0) {
+					for (String j :  restrictionsValuesFromClass.keySet()) { 
+						if (j==property_name) {							
+							Map<String,String> valor=restrictionsValuesFromClass.get(property_name);
+							for (String i : valor.keySet() ) { 
+								restrictionsValues.put(restriction, i);
+								restrictionsValuesFromClass.remove(property_name);
+								restrictionsValuesFromClass.put(property_name, restrictionsValues);
+							}
+						}
+					}
+				}
+				else {
+					restrictionsValues.put(restriction, "");			
+					restrictionsValuesFromClass.put(property_name, restrictionsValues);
+				}
+			}       
+		}
+	}
+
+	public Map<String, Map<String,String>> getRestrictionsValuesFromClass(){
+		return restrictionsValuesFromClass;
+	}
+
+
+	public List<OWLObjectProperty> getPropertiesFromObjectRestrictions(){
+		return propertiesFromObjectRestrictions;
+	}
+
+	public Map<String, List<String>> getPropertiesFromObjectRestrictions_ranges(){
+		return  propertiesFromObjectRestrictions_ranges;
+	}
+}

--- a/src/test/java/edu/isi/oba/RestrictionsTest.java
+++ b/src/test/java/edu/isi/oba/RestrictionsTest.java
@@ -1,0 +1,374 @@
+package edu.isi.oba;
+
+
+import static edu.isi.oba.ObaUtils.get_yaml_data;
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.ConsoleHandler;
+import java.util.logging.Level;
+import java.util.logging.LogManager;
+import java.util.logging.Logger;
+
+import org.junit.Test;
+import org.semanticweb.owlapi.model.OWLClass;
+import org.semanticweb.owlapi.model.OWLOntologyCreationException;
+
+
+import edu.isi.oba.config.YamlConfig;
+import io.swagger.v3.oas.models.media.ArraySchema;
+import io.swagger.v3.oas.models.media.ComposedSchema;
+import io.swagger.v3.oas.models.media.ObjectSchema;
+import io.swagger.v3.oas.models.media.Schema;
+
+public class RestrictionsTest {
+	static Logger logger = null;
+	
+	/**
+	 * This method allows you to configure the logger variable that is required to print several 
+	 * messages during the OBA execution.
+	 */
+	public void initializeLogger() throws Exception {
+		InputStream stream = Oba.class.getClassLoader().getResourceAsStream("logging.properties");
+		try {
+			LogManager.getLogManager().readConfiguration(stream);
+			edu.isi.oba.Oba.logger = Logger.getLogger(Oba.class.getName());
+
+		} catch (IOException e) {
+			e.printStackTrace();
+		}	    
+		edu.isi.oba.Oba.logger.setLevel(Level.FINE);
+		edu.isi.oba.Oba.logger.addHandler(new ConsoleHandler());
+	}
+	
+	/**
+	 * This test attempts to get the OAS representation of a FunctionalObjectProperty.
+	 */
+	@Test
+	public void testFunctionalObjectProperty() throws OWLOntologyCreationException, Exception {
+		try {
+			this.initializeLogger();
+			Integer expectedResult = 1;
+			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
+			Mapper mapper = new Mapper(config_data);
+			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#University");
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0));
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true);
+			Schema schema = mapperSchema.getSchema();	  	       
+			Object property= schema.getProperties().get("hasRector");	       	        
+			if (property instanceof io.swagger.v3.oas.models.media.ArraySchema) {	        	
+				Integer maxItems = ((ArraySchema) property).getMaxItems();
+				assertEquals(expectedResult,maxItems);
+			}			
+		} catch (OWLOntologyCreationException e) {			
+			assertTrue("error in ontology creation", false);
+		}
+	}
+	
+	/**
+	 * This test attempts to get the OAS representation of a ObjectUnionOf restriction.
+	 */
+	@Test
+	public void testObjectUnionOf() throws OWLOntologyCreationException, Exception {		
+		List<String> expectedResult = new ArrayList<String>();
+		expectedResult.add("#/components/schemas/Organization");
+		expectedResult.add("#/components/schemas/Person");
+		try {	
+			this.initializeLogger();
+			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
+			Mapper mapper = new Mapper(config_data);
+			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#StudyMaterial");
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0));
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true);
+			Schema schema = mapperSchema.getSchema();	  	       
+			Object property= schema.getProperties().get("author");		        
+			if (property instanceof ArraySchema) {	
+				Schema items = ((ArraySchema) property).getItems();
+				List<Schema> itemsValue;
+				if (items instanceof ComposedSchema) {
+					itemsValue =((ComposedSchema) items).getAnyOf();
+					for (int i=0; i<itemsValue.size(); i++ ) {
+						String ref = itemsValue.get(i).get$ref();
+						assertEquals(ref,expectedResult.get(i));
+					}	        	
+				}	
+			} 
+		} catch (OWLOntologyCreationException e) {			
+			assertTrue("error in ontology creation", false);
+		}
+	}
+	
+	/**
+	 * This test attempts to get the OAS representation of a ObjectIntersectionOf restriction.
+	 */
+	@Test
+	public void testObjectIntersectionOf() throws OWLOntologyCreationException, Exception {
+		List<String> expectedResult = new ArrayList<String>();			
+		expectedResult.add("#/components/schemas/Assignment");
+		expectedResult.add("#/components/schemas/Exam");
+		
+		try {
+			this.initializeLogger();
+			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
+			Mapper mapper = new Mapper(config_data);
+			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#Course");
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0));
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true);
+			Schema schema = mapperSchema.getSchema();	  	       
+			Object property= schema.getProperties().get("hasEvaluationMethod");		        
+			if (property instanceof ArraySchema) {	
+				Schema items = ((ArraySchema) property).getItems();
+				List<Schema> itemsValue;
+				if (items instanceof ComposedSchema) {
+					itemsValue =((ComposedSchema) items).getAllOf();
+					for (int i=0; i<itemsValue.size(); i++ ) {
+						String ref = itemsValue.get(i).get$ref();
+						assertEquals(ref,expectedResult.get(i));
+					}	        	
+				}	
+			} 
+		} catch (OWLOntologyCreationException e) {			
+			assertTrue("error in ontology creation", false);
+		}
+	}
+	
+	/**
+	 * This test attempts to get the OAS representation of a ObjectSomeValuesFrom without a complex restriction
+	 * e.g. it doesn't include a union.
+	 */
+	@Test
+	public void testSimpleObjectSomeValuesFrom() throws OWLOntologyCreationException, Exception {
+		try {
+			this.initializeLogger();
+			Boolean expectedResult=false;
+			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
+			Mapper mapper = new Mapper(config_data);
+			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#University");
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0));
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true);
+			Schema schema = mapperSchema.getSchema();	  	       
+			Object property= schema.getProperties().get("hasDepartment");		        
+			if (property instanceof ArraySchema) {	
+				Boolean nullable = ((ArraySchema) property).getNullable();
+				assertEquals(nullable,expectedResult);					
+			} 
+		} catch (OWLOntologyCreationException e) {			
+			assertTrue("error in ontology creation", false);
+		}
+	}
+
+	/**
+	 * This test attempts to get the OAS representation of a ObjectSomeValuesFrom which includes another 
+	 * restriction e.g. UnionOf.
+	 */
+	@Test
+	public void testObjectSomeValuesFrom_ComposedByRestriction() throws OWLOntologyCreationException, Exception {
+		List<String> expectedResult = new ArrayList<String>();			
+		expectedResult.add("#/components/schemas/BachelorProgram");
+		expectedResult.add("#/components/schemas/MasterProgram");
+		expectedResult.add("#/components/schemas/PhDProgram");
+		try {
+			this.initializeLogger();
+			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
+			Mapper mapper = new Mapper(config_data);
+			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#Student");
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0));
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true);
+			Schema schema = mapperSchema.getSchema();	  	       
+			Object property= schema.getProperties().get("enrolledIn");		        
+			if (property instanceof ArraySchema) {	
+				Boolean nullable = ((ArraySchema) property).getNullable();
+				Schema items = ((ArraySchema) property).getItems();
+				List<Schema> itemsValue;
+				if (items instanceof ComposedSchema) {
+					itemsValue =((ComposedSchema) items).getAnyOf();
+					for (int i=0; i<itemsValue.size(); i++ ) {			
+						assertEquals(itemsValue.get(i).get$ref(),expectedResult.get(i));
+					}	        	
+				}	
+				assertEquals(nullable,false);					
+			} 			
+		} catch (OWLOntologyCreationException e) {			
+			assertTrue("error in ontology creation", false);
+		}	
+
+	}
+	
+	/**
+	 * This test attempts to get the OAS representation of the exact cardinality of an ObjectProperty.
+	 */
+	@Test
+	public void testObjectExactCardinality() throws OWLOntologyCreationException, Exception {
+		try {
+			this.initializeLogger();
+			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
+			Mapper mapper = new Mapper(config_data);
+			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#AmericanStudent");
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0));
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true);
+			Schema schema = mapperSchema.getSchema();	  	       
+			Object property= schema.getProperties().get("hasRecord");		        
+			if (property instanceof ArraySchema) {					
+				Integer maxItems = ((ArraySchema) property).getMaxItems();
+				Integer minItems = ((ArraySchema) property).getMinItems();
+				if (maxItems!=null && minItems!=null) {
+					if (maxItems == minItems)
+						assertTrue("Exact cardinality configured", true);
+					else
+						assertTrue("Error in exact cardinality restriction", false);
+				} else
+					assertTrue("Null values in exact cardinality restriction.", false);								
+			} 			
+		} catch (OWLOntologyCreationException e) {			
+			assertTrue("Error in ontology creation", false);
+		}	  
+	}
+	
+	/**
+	 * This test attempts to get the OAS representation of the minimum cardinality of an ObjectProperty.
+	 */
+	@Test
+	public void testObjectMinCardinality() throws OWLOntologyCreationException, Exception {
+		try {
+			this.initializeLogger();
+			Integer expectedResult = 2;
+			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
+			Mapper mapper = new Mapper(config_data);
+			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#AmericanStudent");
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0));
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true);
+			Schema schema = mapperSchema.getSchema();	  	       
+			Object property= schema.getProperties().get("takesCourse");		        
+			if (property instanceof ArraySchema) {									
+				Integer minItems = ((ArraySchema) property).getMinItems();
+				if (minItems!=null) {
+					Schema items = ((ArraySchema) property).getItems();
+					assertEquals(items.get$ref(),"#/components/schemas/Course");
+					assertEquals(minItems,expectedResult);
+				} else
+					assertTrue("Wrong values in minimum cardinality restriction.", false);								
+			} 			
+		} catch (OWLOntologyCreationException e) {			
+			assertTrue("Error in ontology creation", false);
+		}	  
+	}
+	
+	/**
+	 * This test attempts to get the OAS representation of the maximum cardinality of an ObjectProperty.
+	 */
+	@Test
+	public void testObjectMaxCardinality() throws OWLOntologyCreationException, Exception {
+		try {
+			this.initializeLogger();
+			Integer expectedResult = 20;
+			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
+			Mapper mapper = new Mapper(config_data);
+			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#Course");
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0));
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true);
+			Schema schema = mapperSchema.getSchema();	  	       
+			Object property= schema.getProperties().get("hasStudentEnrolled");		        
+			if (property instanceof ArraySchema) {									
+				Integer maxItems = ((ArraySchema) property).getMaxItems();
+				if (maxItems!=null) {
+					Schema items = ((ArraySchema) property).getItems();
+					assertEquals(items.get$ref(),"#/components/schemas/Student");
+					assertEquals(maxItems,expectedResult);
+				} else
+					assertTrue("Wrong values in maximum cardinality restriction.", false);								
+			} 			
+		} catch (OWLOntologyCreationException e) {			
+			assertTrue("Error in ontology creation", false);
+		}	
+
+	}
+	
+
+	/**
+	 * This test attempts to get the OAS representation of the complementOf of an ObjectProperty.
+	 */
+	@Test
+	public void testObjectComplementOf() throws OWLOntologyCreationException, Exception {
+		try {
+			this.initializeLogger();
+			String expectedResult = "#/components/schemas/ProfessorInArtificialIntelligence";
+			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
+			Mapper mapper = new Mapper(config_data);
+			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#ProfessorInOtherDepartment");
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0));
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true);
+			Schema schema = mapperSchema.getSchema();	
+			if (schema.getNot()!=null)
+				assertEquals(schema.getNot().get$ref(),expectedResult);				
+			else
+				assertTrue("Wrong configuration of ComplementOf restriction", false);
+				
+		} catch (OWLOntologyCreationException e) {			
+			assertTrue("Error in ontology creation", false);
+		}	
+	}
+	
+	/**
+	 * This test attempts to get the OAS representation of the hasValue of an ObjectProperty.
+	 */
+	@Test
+	public void testObjectHasValue() throws OWLOntologyCreationException, Exception {
+		try {
+			this.initializeLogger();
+			String expectedResult = "<https://w3id.org/example/resource/Department/ArtificialIntelligenceDepartment>";
+			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
+			Mapper mapper = new Mapper(config_data);
+			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#ProfessorInArtificialIntelligence");
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0));
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true);
+			Schema schema = mapperSchema.getSchema();	  	       
+			Object property= schema.getProperties().get("belongsTo");	
+			if (((ObjectSchema) property).getDefault()!=null)
+				assertEquals(((ObjectSchema) property).getDefault(),expectedResult);				
+			else
+				assertTrue("Wrong configuration of ObjectHasValue restriction", false);
+				
+		} catch (OWLOntologyCreationException e) {			
+			assertTrue("Error in ontology creation", false);
+		}	    
+	}
+	
+	/**
+	 * This test attempts to get the OAS representation of the oneOf restriction of an ObjectProperty.
+	 */
+	@Test
+	public void testObjectOneOf() throws OWLOntologyCreationException, Exception {
+		try {
+			this.initializeLogger();
+			List<String> expectedResult = new ArrayList<String>();
+			expectedResult.add("<https://w3id.org/example/resource/Degree/MS>");
+			expectedResult.add("<https://w3id.org/example/resource/Degree/PhD>");
+			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
+			Mapper mapper = new Mapper(config_data);
+			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#Professor");
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0));
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true);
+			Schema schema = mapperSchema.getSchema();	  	       
+			Object property= schema.getProperties().get("hasDegree");		        
+
+			if (property instanceof ArraySchema) {	
+				Schema items = ((ArraySchema) property).getItems();
+				List<Object> itemsValue;
+				if (items instanceof ComposedSchema) {
+					itemsValue =((ComposedSchema) items).getEnum();
+					for (int i=0; i<itemsValue.size(); i++ ) {
+						Object ref = itemsValue.get(i);
+						assertEquals(ref.toString(),expectedResult.get(i));
+					}	        	
+				}	
+			} 
+
+		} catch (OWLOntologyCreationException e) {			
+			assertTrue("Error in ontology creation", false);
+		}	
+	}
+
+}

--- a/src/test/java/edu/isi/oba/RestrictionsTest.java
+++ b/src/test/java/edu/isi/oba/RestrictionsTest.java
@@ -13,6 +13,7 @@ import java.util.logging.Level;
 import java.util.logging.LogManager;
 import java.util.logging.Logger;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.semanticweb.owlapi.model.OWLClass;
 import org.semanticweb.owlapi.model.OWLOntologyCreationException;
@@ -369,6 +370,347 @@ public class RestrictionsTest {
 		} catch (OWLOntologyCreationException e) {			
 			assertTrue("Error in ontology creation", false);
 		}	
+	}
+
+	
+	/**
+	 * This test attempts to get the OAS representation of a FunctionalDataProperty.
+	 */
+	@Test
+	public void testFunctionalDataProperty() throws OWLOntologyCreationException, Exception {
+		try {
+			this.initializeLogger();
+			Integer expectedResult = 1;
+			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
+			Mapper mapper = new Mapper(config_data);
+			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#AmericanStudent");
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0));
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true);
+			Schema schema = mapperSchema.getSchema();	  	       
+			Object property= schema.getProperties().get("birthDate");	       	        
+			if (property instanceof io.swagger.v3.oas.models.media.ArraySchema) {	        	
+				Integer maxItems = ((ArraySchema) property).getMaxItems();
+				assertEquals(expectedResult,maxItems);
+			}			
+		} catch (OWLOntologyCreationException e) {			
+			assertTrue("error in ontology creation", false);
+		}
+	}
+	
+	/**
+	 * This test attempts to get the OAS representation of the UnionOf restriction of a DataProperty.
+	 */
+	@Test
+	public void testDataUnionOf() throws OWLOntologyCreationException, Exception {
+		try {
+			this.initializeLogger();
+			List<String> expectedResult = new ArrayList<String>();
+			expectedResult.add("number");
+			expectedResult.add("integer");
+
+			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
+			Mapper mapper = new Mapper(config_data);
+			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#Course");
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0));
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true);
+			Schema schema = mapperSchema.getSchema();	  	       
+			Object property= schema.getProperties().get("ects");		        
+			if (property instanceof ArraySchema) {	
+				Schema items = ((ArraySchema) property).getItems();
+				List<Schema> itemsValue;
+				if (items instanceof ComposedSchema) {
+					itemsValue =((ComposedSchema) items).getAnyOf();
+					for (int i=0; i<itemsValue.size(); i++ ) {
+						String ref = itemsValue.get(i).getType();
+						assertEquals(ref,expectedResult.get(i));
+					}	        	
+				}	
+			} 
+		} catch (OWLOntologyCreationException e) {			
+			assertTrue("error in ontology creation", false);
+		}
+	}
+
+	/**
+	 * This test attempts to get the OAS representation of the UnionOf restriction of a DataProperty.
+	 */
+	@Test
+	public void testDataIntersectionOf() throws OWLOntologyCreationException, Exception {
+		try {
+			this.initializeLogger();
+			List<String> expectedResult = new ArrayList<String>();
+			expectedResult.add("integer");
+			expectedResult.add("integer");
+
+			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
+			Mapper mapper = new Mapper(config_data);
+			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#ProfessorInArtificialIntelligence");
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0));
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true);
+			Schema schema = mapperSchema.getSchema();	  	       
+			Object property= schema.getProperties().get("memberOfOtherDepartments");		        
+			if (property instanceof ArraySchema) {	
+				Schema items = ((ArraySchema) property).getItems();
+				List<Schema> itemsValue;
+				if (items instanceof ComposedSchema) {
+					itemsValue =((ComposedSchema) items).getAllOf();
+					for (int i=0; i<itemsValue.size(); i++ ) {
+						String ref = itemsValue.get(i).getType();
+						assertEquals(ref,expectedResult.get(i));
+					}	        	
+				}	
+			} 
+		} catch (OWLOntologyCreationException e) {			
+			assertTrue("error in ontology creation", false);
+		}
+	}
+	
+	/**
+	 * This test attempts to get the OAS representation of the SomeValuesFrom restriction of a DataProperty.
+	 */
+	@Ignore
+	public void testDataSomeValuesFrom() throws OWLOntologyCreationException, Exception {
+		try {
+			this.initializeLogger();
+			String expectedResult = "string";
+			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
+			Mapper mapper = new Mapper(config_data);
+			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#StudyProgram");
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0));
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true);
+			Schema schema = mapperSchema.getSchema();	  	       
+			Object property= schema.getProperties().get("studyProgramName");		        
+			if (property instanceof ArraySchema) {	
+				Boolean nullable = ((ArraySchema) property).getNullable();
+				assertEquals(((ArraySchema) property).getItems().getType(), expectedResult);
+				assertEquals(nullable,false);	
+			} 
+		} catch (OWLOntologyCreationException e) {			
+			assertTrue("error in ontology creation", false);
+		}
+	}
+
+	/**
+	 * This test attempts to get the OAS representation of a DataSomeValuesFrom which includes another restriction.
+	 * e.g. IntersectionOf
+	 */
+	@Test
+	public void testDataSomeValuesFrom_ComposedByRestriction() throws OWLOntologyCreationException, Exception {
+		try {
+			this.initializeLogger();
+			List<String> expectedResult = new ArrayList<String>();			
+			expectedResult.add("integer");
+			expectedResult.add("integer");
+			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
+			Mapper mapper = new Mapper(config_data);
+			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#ProfessorInArtificialIntelligence");
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0));
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true);
+			Schema schema = mapperSchema.getSchema();	  	       
+			Object property= schema.getProperties().get("memberOfOtherDepartments");		        
+			if (property instanceof ArraySchema) {	
+				Boolean nullable = ((ArraySchema) property).getNullable();
+				Schema items = ((ArraySchema) property).getItems();
+				List<Schema> itemsValue;
+				if (items instanceof ComposedSchema) {
+					itemsValue =((ComposedSchema) items).getAllOf();
+					for (int i=0; i<itemsValue.size(); i++ ) {			
+						assertEquals(itemsValue.get(i).getType(),expectedResult.get(i));
+					}	        	
+				}	
+				assertEquals(nullable,false);					
+			} 			
+		} catch (OWLOntologyCreationException e) {			
+			assertTrue("error in ontology creation", false);
+		}	    		
+	}
+	
+	/**
+	 * This test attempts to get the OAS representation of the AllValuesFrom restriction of a DataProperty.
+	 */
+	@Test
+	public void testDataAllValuesFrom() throws OWLOntologyCreationException, Exception {
+		try {
+			this.initializeLogger();
+			String expectedResult = "string";
+			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
+			Mapper mapper = new Mapper(config_data);
+			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#StudyProgram");
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0));
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true);
+			Schema schema = mapperSchema.getSchema();	  	       
+			Object property= schema.getProperties().get("studyProgramName");		        
+			if (property instanceof ArraySchema) {	
+				assertEquals(((ArraySchema) property).getItems().getType(), expectedResult);
+			} 
+		} catch (OWLOntologyCreationException e) {			
+			assertTrue("error in ontology creation", false);
+		}
+	}
+	
+	/**
+	 * This test attempts to get the OAS representation of the OneOf restriction of a DataProperty.
+	 */
+	@Test
+	public void testDataOneOf() throws OWLOntologyCreationException, Exception {
+		try {
+			this.initializeLogger();
+			List<String> expectedResult = new ArrayList<String>();			
+			expectedResult.add("female");
+			expectedResult.add("male");
+			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
+			Mapper mapper = new Mapper(config_data);
+			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#Person");
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0));
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true);
+			Schema schema = mapperSchema.getSchema();	  	       
+			Object property= schema.getProperties().get("gender");	
+			if (property instanceof ArraySchema) {	
+				Schema items = ((ArraySchema) property).getItems();
+				List<Object> itemsValue;
+				if (items instanceof ComposedSchema) {
+					itemsValue =((ComposedSchema) items).getEnum();
+					for (int i=0; i<itemsValue.size(); i++ ) {			
+						assertEquals(itemsValue.get(i),expectedResult.get(i));
+					}	        	
+				}						
+			} 			
+			else
+				assertTrue("Wrong configuration of DataOneOf restriction", false);
+				
+		} catch (OWLOntologyCreationException e) {			
+			assertTrue("Error in ontology creation", false);
+		}	    			
+	}
+	
+	/**
+	 * This test attempts to get the OAS representation of the hasValue restriction of a DataProperty.
+	 */
+	@Test
+	public void testDataHasValue() throws OWLOntologyCreationException, Exception {
+		try {
+			this.initializeLogger();
+			String expectedResult = "American";
+			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
+			Mapper mapper = new Mapper(config_data);
+			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#AmericanStudent");
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0));
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true);
+			Schema schema = mapperSchema.getSchema();	  	       
+			Object property= schema.getProperties().get("nationality");	
+			
+			if (((ArraySchema) property).getItems().getDefault()!=null)
+				assertEquals(((ArraySchema) property).getItems().getDefault(),expectedResult);				
+			else
+				assertTrue("Wrong configuration of DataHasValue restriction", false);
+				
+		} catch (OWLOntologyCreationException e) {			
+			assertTrue("Error in ontology creation", false);
+		}	    			
+	}
+	
+	/**
+	 * This test attempts to get the OAS representation of the exact cardinality of a DataProperty.
+	 */
+	@Test
+	public void testDataExactCardinality() throws OWLOntologyCreationException,Exception {
+		try {
+			this.initializeLogger();
+			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
+			Mapper mapper = new Mapper(config_data);
+			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#University");
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0));
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true);
+			Schema schema = mapperSchema.getSchema();	  	       
+			Object property= schema.getProperties().get("universityName");		        					
+				Integer maxItems = ((ArraySchema) property).getItems().getMaxItems();
+				Integer minItems = ((ArraySchema) property).getItems().getMinItems();
+				if (maxItems!=null && minItems!=null) {
+					if (maxItems == minItems)
+						assertTrue("Exact cardinality configured", true);
+					else
+						assertTrue("Error in exact cardinality restriction", false);
+			} 			
+		} catch (OWLOntologyCreationException e) {			
+			assertTrue("Error in ontology creation", false);
+		}	    			
+	}
+	
+	/**
+	 * This test attempts to get the OAS representation of the minimum cardinality of a DataProperty.
+	 */
+	@Test
+	public void testDataMinCardinality() throws OWLOntologyCreationException, Exception {
+		try {
+			this.initializeLogger();
+			Integer expectedResult = 1;
+			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
+			Mapper mapper = new Mapper(config_data);
+			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#Professor");
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0));
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true);
+			Schema schema = mapperSchema.getSchema();	  	       
+			Object property= schema.getProperties().get("researchField");		        					
+			Integer minItems = ((ArraySchema) property).getItems().getMinItems();
+			if (minItems!=null) 
+				assertEquals(minItems,expectedResult);
+			else
+				assertTrue("Error in minimum cardinality restriction", false);
+						
+		} catch (OWLOntologyCreationException e) {			
+			assertTrue("Error in ontology creation", false);
+		}	    			
+	}
+	
+	/**
+	 * This test attempts to get the OAS representation of the maximum cardinality of a DataProperty.
+	 */
+	@Test
+	public void testDataMaxCardinality() throws OWLOntologyCreationException, Exception {
+		try {
+			this.initializeLogger();
+			Integer expectedResult = 2;
+			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
+			Mapper mapper = new Mapper(config_data);
+			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#Person");
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0));
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true);
+			Schema schema = mapperSchema.getSchema();	  	       
+			Object property= schema.getProperties().get("address");		        					
+			Integer maxItems = ((ArraySchema) property).getItems().getMaxItems();
+			if (maxItems!=null) 
+				assertEquals(maxItems,expectedResult);
+			else
+				assertTrue("Error in maximum cardinality restriction", false);
+
+		} catch (OWLOntologyCreationException e) {			
+			assertTrue("Error in ontology creation", false);
+		}	    			
+	}
+	
+	/**
+	 * This test attempts to get the OAS representation of the complementOf of a DataProperty.
+	 */
+	@Test
+	public void testDataComplementOf() throws OWLOntologyCreationException,Exception {
+		try {
+			this.initializeLogger();
+			String expectedResult = "integer";
+			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
+			Mapper mapper = new Mapper(config_data);
+			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#Department");
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0));
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true);
+			Schema schema = mapperSchema.getSchema();	
+			Object property= schema.getProperties().get("numberOfProfessors");				
+			if (((ArraySchema) property).getItems().getNot()!=null)
+				assertEquals(((ArraySchema) property).getItems().getNot().getType(),expectedResult);				
+			else
+				assertTrue("Wrong configuration of ComplementOf restriction", false);
+				
+		} catch (OWLOntologyCreationException e) {			
+			assertTrue("Error in ontology creation", false);
+		}	    			
 	}
 
 }


### PR DESCRIPTION
- It includes the Restriction Visitor Class to inspect each restriction over both Classes and Object Properties. The supported restrictions are: ObjectSomeValuesFrom, ObjectAllValuesFrom, ObjectUnionOf, ObjectIntersectionOf, ObjectComplementOf, ObjectHasValue, ObjectMinCardinality, ObjectMaxCardinality, and ObjectExactCardinality.

- Included support for DATETIME_TYPE values.

- Updated example ontology to include some complex restrictions to test with OBA.

- Updated saref4city example to get the ontology from the Web.