### PR TITLE
Correctly output enums in .yaml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <packaging>jar</packaging>
     <groupId>edu.isi.oba</groupId>
     <artifactId>oba</artifactId>
-    <version>3.7.0</version>
+    <version>3.7.1</version>
     <name>core</name>
     <url>https://github.com/KnowledgeCaptureAndDiscovery/OBA</url>
 

--- a/src/main/java/edu/isi/oba/MapperDataProperty.java
+++ b/src/main/java/edu/isi/oba/MapperDataProperty.java
@@ -99,10 +99,10 @@ class MapperDataProperty {
 
   public Schema getSchemaByDataProperty(){
 	  
-    if (this.type.size() == 0) {
+    if (this.type.isEmpty()) {
       return (array) ? arraySchema(new StringSchema(), nullable) : new StringSchema().nullable(nullable).description(description);
     }
-    else if (this.type.size() > 1){
+    else if (this.type.size() > 1) {
     	return (array) ? composedSchema(this.type, nullable) : new Schema().nullable(nullable).description(description);
     }
 
@@ -110,6 +110,7 @@ class MapperDataProperty {
     if (schemaType == null){
       logger.severe("property " + this.name + " type " + this.type);
     }
+    
     switch (schemaType) {
       case STRING_TYPE:
         return (array) ? arraySchema(new StringSchema(), nullable) : new StringSchema().nullable(nullable).description(description);

--- a/src/main/java/edu/isi/oba/MapperObjectProperty.java
+++ b/src/main/java/edu/isi/oba/MapperObjectProperty.java
@@ -4,8 +4,10 @@ import io.swagger.v3.oas.models.media.*;
 
 import static edu.isi.oba.Oba.logger;
 
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 class MapperObjectProperty {
   final String name;
@@ -37,60 +39,60 @@ class MapperObjectProperty {
     this.restrictions = restrictions;
   }
 
-  public Schema getSchemaByObjectProperty(){
-    if (this.ref.size() == 0){
-      return getComposedSchemaObject(this.ref, array, nullable);
+  public Schema getSchemaByObjectProperty() {
+    if (this.ref.isEmpty()){
+      return getComposedSchemaObject(this.ref, this.array, this.nullable);
     }
 
     if (this.ref.size() > 1){
-      return getComposedSchemaObject(this.ref, array, nullable);
-    }
-    else {
-      return getObjectPropertiesByRef(this.ref.get(0), array, nullable);
+      return getComposedSchemaObject(this.ref, this.array, this.nullable);
+    } else {
+      return getObjectPropertiesByRef(this.ref.get(0), this.array, this.nullable);
     }
   }
 
-  private Schema getObjectPropertiesByRef(String ref, boolean array, boolean nullable){
+  private Schema getObjectPropertiesByRef(String ref, boolean array, boolean nullable) {
     Schema object = new ObjectSchema();
-    object.setDescription(description);
+    object.setDescription(this.description);
 
     if (array) {
       object.set$ref(ref);
       ArraySchema objects = new ArraySchema();
-      objects.setDescription(description);
-      if (isFunctional)
+      objects.setDescription(this.description);
+
+      if (this.isFunctional) {
           objects.setMaxItems(1);
+      }
       
-      for (String restriction:  restrictions.keySet()) { 
-    	  String value = restrictions.get(restriction);
-      switch (restriction) {
-      case "maxCardinality":
-    	objects.setMaxItems(Integer.parseInt(value));
-      	break ;
-      case "minCardinality":	
-    	  objects.setMinItems(Integer.parseInt(value));
-      	break ;
-      case "exactCardinality":
-    	  objects.setMaxItems(Integer.parseInt(value));
-    	  objects.setMinItems(Integer.parseInt(value));
-      	break ;
-      case "someValuesFrom": 
-    	  nullable=false;
-      	break ;
-      case "allValuesFrom":      	  
-    	  //nothing to do in the Schema
-      	break ;   
-      default:
-    	  break ; 
-    	} 
+      for (String restriction:  this.restrictions.keySet()) {
+    	  String value = this.restrictions.get(restriction);
+        switch (restriction) {
+        case "maxCardinality":
+        objects.setMaxItems(Integer.parseInt(value));
+          break;
+        case "minCardinality":
+          objects.setMinItems(Integer.parseInt(value));
+          break;
+        case "exactCardinality":
+          objects.setMaxItems(Integer.parseInt(value));
+          objects.setMinItems(Integer.parseInt(value));
+          break;
+        case "someValuesFrom":
+          nullable=false;
+          break;
+        case "allValuesFrom":
+          //nothing to do in the Schema
+          break;
+        default:
+          break;
+        }
       }     
       objects.setNullable(nullable);
       objects.setItems(object);      
       return objects;
-    }
-    else {
-    	for (String restriction:  restrictions.keySet()) { 
-    		String value = restrictions.get(restriction);
+    } else {
+    	for (String restriction:  this.restrictions.keySet()) { 
+    		String value = this.restrictions.get(restriction);
     		if (restriction=="objectHasValue") {      		
     			object.setDefault(value);
     			object.type("string");
@@ -98,72 +100,88 @@ class MapperObjectProperty {
     			return object;
     		}
     	}
+
     	return object;
     }
 
     
   }
-  private Schema getComposedSchemaObject(List<String> refs, boolean array, boolean nullable){
+  private Schema getComposedSchemaObject(List<String> refs, boolean array, boolean nullable) {
     Schema object = new ObjectSchema();
-    ComposedSchema composedSchema = new ComposedSchema() ;
+    ComposedSchema composedSchema = new ComposedSchema();
     
     object.setType("object");
-    object.setDescription(description);
+    object.setDescription(this.description);
 
     if (array) {
     	ArraySchema objects = new ArraySchema();
-    	objects.setDescription(description);
+    	objects.setDescription(this.description);
     	
-    	if (isFunctional)
+    	if (this.isFunctional) {
     		objects.setMaxItems(1);
+      }
 
-    	for (String restriction:  restrictions.keySet()) { 
-    		String value = restrictions.get(restriction); 
+    	for (String restriction:  this.restrictions.keySet()) { 
+        String value = this.restrictions.get(restriction);
 
-    		for (String item:refs) {
+        // In some cases, the duplicate reference may have been added to the list.  We only need to create one $ref item to it.
+        LinkedHashSet<String> uniqueRefs = refs.stream().collect(Collectors.toCollection(LinkedHashSet::new));
+
+    		for (String item: uniqueRefs) {
     			Schema objectRange = new ObjectSchema();
     			objectRange.setType("object");
     			objectRange.set$ref(item);
+
     			switch (restriction) {
     			case "unionOf":
-    				if (value=="someValuesFrom")
-    					nullable=false;	
+    				if ("someValuesFrom".equals(value)) {
+    					nullable=false;
+            }
+
     				composedSchema.addAnyOfItem(objectRange);
     				objects.setItems(composedSchema);
-    				break ;
+    				break;
     			case "intersectionOf":
-    				if (value=="someValuesFrom")
-    					nullable=false;	
+    				if ("someValuesFrom".equals(value)) {
+    					nullable = false;
+            }
+
     				composedSchema.addAllOfItem(objectRange);
     				objects.setItems(composedSchema);
-    				break ;
-    			case "someValuesFrom": 
-    				nullable=false;
     				break;
-    			case "allValuesFrom":      	  
+    			case "someValuesFrom":
+    				nullable=false;
+            composedSchema.addAnyOfItem(objectRange);
+            objects.setItems(composedSchema);
+    				break;
+    			case "allValuesFrom":
     				//nothing to do in the Schema
-    				break ;  
-    	        case "oneOf":  
-    	        	if (value=="someValuesFrom")
-    	        		nullable=false;	
-    	        	composedSchema.addEnumItemObject(item);
-    	            composedSchema.setType("string");
-    	            composedSchema.setFormat("uri");
-    	        	objects.setItems(composedSchema);
-    	        	break;
+    				break;
+    	    case "oneOf":
+            if (value=="someValuesFrom") {
+              nullable=false;
+            }
+
+            composedSchema.addEnumItemObject(item);
+            composedSchema.setType("string");
+            composedSchema.setFormat("uri");
+            objects.setItems(composedSchema);
+            break;
     			default:
     				//if the property range is complex it will be omitted   
-    				logger.warning("omitted complex restriction");	 
-    				objects.setItems(object); 		          
+    				logger.warning("omitted complex restriction");
+    				objects.setItems(object);
     			}             
     		}
-    	}     
-    	if (refs.size() == 0)
-    		objects.setItems(object);
-    		objects.setNullable(nullable);
+    	}
+
+    	if (refs.isEmpty()) {
+        objects.setItems(object);
+      }
+    	objects.setNullable(nullable);
+
     	return objects;
-    }
-    else {
+    } else {
       return object;
     }
   }

--- a/src/main/java/edu/isi/oba/Serializer.java
+++ b/src/main/java/edu/isi/oba/Serializer.java
@@ -62,7 +62,7 @@ class Serializer {
     List<String> messageList = result.getMessages();
     Set<String> errors = new HashSet<>(messageList);
     Set<String> warnings = new HashSet<>();
-    if (errors.size() > 0) {
+    if (!errors.isEmpty()) {
       throw new Exception("Error when validating the API specification. " + errors.iterator().next());
     }
   }


### PR DESCRIPTION
Enums are not output to .yaml currently.  This PR aims to fix that.

For example, the Turtle snippet below from the Pizza Tutorial does not produce an enum for Spiciness which contains the values `Hot`, `Medium`, and `Mild`:
```
    <!-- http://www.semanticweb.org/.../pizzatutorial#Spiciness -->

    <owl:Class rdf:about="http://www.semanticweb.org/.../pizzatutorial#Spiciness">
        <owl:equivalentClass rdf:nodeID="genid51"/>
    </owl:Class>
    <owl:Class rdf:nodeID="genid51">
        <owl:oneOf rdf:parseType="Collection">
            <rdf:Description rdf:about="http://www.semanticweb.org/.../pizzatutorial#Hot"/>
            <rdf:Description rdf:about="http://www.semanticweb.org/.../pizzatutorial#Medium"/>
            <rdf:Description rdf:about="http://www.semanticweb.org/.../pizzatutorial#Mild"/>
        </owl:oneOf>
    </owl:Class>
    <owl:Axiom>
        <owl:annotatedSource rdf:resource="http://www.semanticweb.org/.../pizzatutorial#Spiciness"/>
        <owl:annotatedProperty rdf:resource="http://www.w3.org/2002/07/owl#equivalentClass"/>
        <owl:annotatedTarget rdf:nodeID="genid51"/>
    </owl:Axiom>
```

The expected output for this schema should be:
```
    Spiciness:
      description: Description not available
      enum:
      - Hot
      - Medium
      - Mild
      type: string
```
but without the current changes, it looks like:
```
    Spiciness:
      description: Description not available
      example:
        value:
          id: some_id
      properties:
        isSpicierThan:
          description: Description not available
          items:
            $ref: "#/components/schemas/Spiciness"
          nullable: true
          type: array
        description:
          description: small description
          items:
            type: string
          nullable: true
          type: array
        id:
          description: identifier
          nullable: false
          type: string
        label:
          description: short description of the resource
          items:
            type: string
          nullable: true
          type: array
        type:
          description: type of the resource
          items:
            type: string
          nullable: true
          type: array
      type: object
```

You can see that not only is the enum aspect of this defined class lost in the yaml output, but the individual enum values are also missing completely.

As I was making the necessary changes to support enums (based on the `owl:oneOf` restrictions mentioned above), I made a handful of other cleanup changes.  Apologies in advance if this makes reviewing difficult.

The cleanup changes included:
- wrapping one line statements (e.g. `if`, `for`, etc.) within curly braces.  (More for safety and a little bit for readability)
- making some whitespace consistent (e.g. one space between method declaration and the `{` that follows)
- adding `this.` when I noticed a class variable is being used.  (good practice, but also readability)
- replacing `.size() == 0` or `.size() !=0` with `.isEmpty()` or `! ... .isEmpty()`.
- removing random whitespace at the end of a line

I will make a future PR to try and make all of the formatting consistent throughout (but without any functional changes).  These formatting updates were mostly localized to where I was already making other changes OR easy to identify/fix.