### PR TITLE
Add default description and default properties flags to config file

### DIFF
--- a/docs/configuration_file.md
+++ b/docs/configuration_file.md
@@ -7,8 +7,7 @@ Below is an example YAML file which may require some changes for your project's 
 You can find examples in [GitHub](https://github.com/KnowledgeCaptureAndDiscovery/OBA/tree/master/examples)
 
 !!! info
-    If you experience any issues when using OBA, or if you would like us to support additional exciting features, please open an issue on our [GitHub repository](https://github.com/KnowledgeCaptureAndDiscovery/OBA/issues).
-
+If you experience any issues when using OBA, or if you would like us to support additional exciting features, please open an issue on our [GitHub repository](https://github.com/KnowledgeCaptureAndDiscovery/OBA/issues).
 
 ```yaml
 #Name of the project
@@ -25,7 +24,7 @@ openapi:
     version: v1.3.0
   externalDocs:
     description: DBpedia
-    url:  http://dbpedia.org/
+    url: http://dbpedia.org/
   servers:
     - url: https://dbpedia.dbpedia.oba.isi.edu/v1.3.0
     - url: http://localhost:8080/v1.3.0
@@ -50,9 +49,15 @@ enable_put_paths: false
 classes:
   - http://dbpedia.org/ontology/Genre
   - http://dbpedia.org/ontology/Band
-follow_references: false
-```
 
+follow_references: false
+
+## Enable/disable generation of a default description for each schema
+default_descriptions: true
+
+## Enable/disable generation of default properties (description, id, label, and type) for each schema
+default_properties: true
+```
 
 ## Supported settings
 
@@ -60,9 +65,9 @@ follow_references: false
 
 The name of OpenAPI
 
-| Field | Value |
-|---|---|
-| **Required:** | ``true`` |
+| Field         | Value  |
+| ------------- | ------ |
+| **Required:** | `true` |
 
 Example:
 
@@ -70,16 +75,14 @@ Example:
 name: dbpedia_music
 ```
 
-
 ### output_dir
 
 The output directory of the OpenApi specification files, relative to the root of the project.
 
-| Field | Value |
-|---|---|
-| **Required:** | ``false`` |
-| **Default:** | ``outputs`` |
-
+| Field         | Value     |
+| ------------- | --------- |
+| **Required:** | `false`   |
+| **Default:**  | `outputs` |
 
 Example:
 
@@ -87,17 +90,15 @@ Example:
 output_dir: outputs
 ```
 
-
 ### OpenAPI
 
 Basic information of API using OpenAPI Spec.
 More info: [OpenAPI Base file](https://swagger.io/docs/specification/basic-structure/)
 
-| Field | Value |
-|---|---|
-| **Required:** | ``true`` |
-| **Type:** | ``OpenAPI`` |
-
+| Field         | Value     |
+| ------------- | --------- |
+| **Required:** | `true`    |
+| **Type:**     | `OpenAPI` |
 
 Example:
 
@@ -110,56 +111,51 @@ openapi:
     version: v1.3.0
   externalDocs:
     description: DBpedia
-    url:  http://dbpedia.org/
+    url: http://dbpedia.org/
   servers:
     - url: https://dbpedia.dbpedia.oba.isi.edu/v1.3.0
     - url: http://localhost:8080/v1.3.0
 ```
 
-
-
 ### enable_get_paths
 
 Enable the GET method for the paths
 
-| Field | Value |
-|---|---|
-| **Required:** | ``false`` |
-| **Type:** | ``boolean``  |
-| **Default:** | ``true``  |
+| Field         | Value     |
+| ------------- | --------- |
+| **Required:** | `false`   |
+| **Type:**     | `boolean` |
+| **Default:**  | `true`    |
 
-### enable_post_paths: 
+### enable_post_paths:
 
 Enable the POST method for the paths
 
-| Field | Value |
-|---|---|
-| **Required:** | ``false`` |
-| **Type:** | ``boolean``  |
-| **Default:** | ``false``  |
-
+| Field         | Value     |
+| ------------- | --------- |
+| **Required:** | `false`   |
+| **Type:**     | `boolean` |
+| **Default:**  | `false`   |
 
 ### enable_delete_paths
 
 Enable the DELETE method for the paths
 
-| Field | Value |
-|---|---|
-| **Required:** | ``false`` |
-| **Type:** | ``boolean``  |
-| **Default:** | ``false``  |
+| Field         | Value     |
+| ------------- | --------- |
+| **Required:** | `false`   |
+| **Type:**     | `boolean` |
+| **Default:**  | `false`   |
 
 ### enable_put_paths
 
 Enable the PUT method for the paths
 
-| Field | Value |
-|---|---|
-| **Required:** | ``false`` |
-| **Type:** | ``boolean``  |
-| **Default:** | ``false``  |
-
-
+| Field         | Value     |
+| ------------- | --------- |
+| **Required:** | `false`   |
+| **Type:**     | `boolean` |
+| **Default:**  | `false`   |
 
 ### endpoint
 
@@ -170,63 +166,56 @@ endpoint:
   url: http://dbpedia.org/sparql
   prefix: http://dbpedia.org/resource
   # Add the GRAPH clause. Enable it when you are using authentication.
-  # OBA uses a graph to store the user contents on a personal namespace. 
+  # OBA uses a graph to store the user contents on a personal namespace.
   # For DBpedia, dont use it.
-  graph: http://endpoint.mint.isi.edu/modelCatalog-1.4.0/data/ 
+  graph: http://endpoint.mint.isi.edu/modelCatalog-1.4.0/data/
 ```
 
 ### endpoint.url
 
-The url of the SPARQL Endpoint 
+The url of the SPARQL Endpoint
 
-| Field | Value |
-|---|---|
-| **Required:** | ``true`` |
-| **Type:** | ``url`` |
-
+| Field         | Value  |
+| ------------- | ------ |
+| **Required:** | `true` |
+| **Type:**     | `url`  |
 
 Example:
 
 ```yaml
-  url: http://dbpedia.org/sparql
+url: http://dbpedia.org/sparql
 ```
 
-
 ### endpoint.prefix
-
 
 The prefix of the SPARQL Endpoint.
 This is useful when you create a new resource.
 
-| Field | Value |
-|---|---|
-| **Required:** | ``true`` |
-| **Type:** | ``url`` |
-
+| Field         | Value  |
+| ------------- | ------ |
+| **Required:** | `true` |
+| **Type:**     | `url`  |
 
 Example:
 
 ```yaml
-  prefix: http://dbpedia.org/resource
+prefix: http://dbpedia.org/resource
 ```
-
 
 ### endpoint.graph_base
 
-OBA uses a graph to store the user contents on a personal namespace. 
+OBA uses a graph to store the user contents on a personal namespace.
 
-| Field | Value |
-|---|---|
-| **Required:** | ``true`` |
-| **Type:** | ``url`` |
-
+| Field         | Value  |
+| ------------- | ------ |
+| **Required:** | `true` |
+| **Type:**     | `url`  |
 
 Example:
 
 ```yaml
-  graph_base: http://ontosoft.isi.edu:3030/modelCatalog-1.2.0/data/
+graph_base: http://ontosoft.isi.edu:3030/modelCatalog-1.2.0/data/
 ```
-
 
 ## ontologies
 
@@ -236,17 +225,18 @@ Example:
 ontologies:
   - https://tinyurl.com/dbpediaoba
 ```
-| Field | Value |
-|---|---|
-| **Required:** | ``true`` |
-| **Type:** | ``List[string]`` |
+
+| Field         | Value          |
+| ------------- | -------------- |
+| **Required:** | `true`         |
+| **Type:**     | `List[string]` |
 
 ## custom_queries_directory
 
-| Field | Value |
-|---|---|
-| **Required:** | ``false`` |
-| **Type:** | ``List[Path]`` |
+| Field         | Value        |
+| ------------- | ------------ |
+| **Required:** | `false`      |
+| **Type:**     | `List[Path]` |
 
 [Go to how to add custom queries](adding_custom_queries.md) for more information
 
@@ -256,10 +246,10 @@ Some ontologies contain numerous classes. However, you can be interested in a su
 
 ### classes
 
-| Field | Value |
-|---|---|
-| **Required:** | ``false`` |
-| **Type:** | ``List[URI]`` |
+| Field         | Value       |
+| ------------- | ----------- |
+| **Required:** | `false`     |
+| **Type:**     | `List[URI]` |
 
 ```yaml
 classes:
@@ -269,12 +259,11 @@ classes:
 
 ### follow_references
 
-| Field | Value |
-|---|---|
-| **Required:** | ``false`` |
-| **Type:** | ``Boolean`` |
-| **Default:** | ``True`` |
-
+| Field         | Value     |
+| ------------- | --------- |
+| **Required:** | `false`   |
+| **Type:**     | `Boolean` |
+| **Default:**  | `True`    |
 
 For more information, go to [filtering classes](filtering.md#following-references)
 
@@ -282,18 +271,48 @@ For more information, go to [filtering classes](filtering.md#following-reference
 follow_references: false
 ```
 
+### default_descriptions
+
+Enable/disable generation of a default description for each schema.
+
+| Field         | Value     |
+| ------------- | --------- |
+| **Required:** | `false`   |
+| **Type:**     | `Boolean` |
+| **Default:**  | `True`    |
+
+For more information, go to [filtering classes](filtering.md#default_descriptions)
+
+```yaml
+default_descriptions: false
+```
+
+### default_properties
+
+Enable/disable generation of default properties (description, id, label, and type) for each schema.
+
+| Field         | Value     |
+| ------------- | --------- |
+| **Required:** | `false`   |
+| **Type:**     | `Boolean` |
+| **Default:**  | `True`    |
+
+For more information, go to [filtering classes](filtering.md#default_properties)
+
+```yaml
+default_properties: false
+```
 
 ## auth
 
 Add login to the API and add security to the following methods: `POST`, `PUT` and `DELETE`
 
-
 ### provider
 
-| Field | Value |
-|---|---|
-| **Required:** | ``true`` |
-| **Type:** | ``str`` |
+| Field         | Value  |
+| ------------- | ------ |
+| **Required:** | `true` |
+| **Type:**     | `str`  |
 
 The providers supported:
 
@@ -314,12 +333,10 @@ firebase:
 
 To authenticate a service account and authorize it to access Firebase services, you must generate a private key file.
 
-
-
-| Field | Value |
-|---|---|
-| **Required:** | ``true`` |
-| **Type:** | ``str`` |
+| Field         | Value  |
+| ------------- | ------ |
+| **Required:** | `true` |
+| **Type:**     | `str`  |
 
 ```
 firebase:

--- a/docs/filtering.md
+++ b/docs/filtering.md
@@ -3,8 +3,8 @@ OBA can filter the classes.
 
 The following example is selecting two classes:
 
-  - http://dbpedia.org/ontology/Genre
-  - http://dbpedia.org/ontology/Band
+- http://dbpedia.org/ontology/Genre
+- http://dbpedia.org/ontology/Band
 
 ```yaml
 ### For more information about the section. Go to the official documentation
@@ -42,11 +42,17 @@ enable_put_paths: false
 classes:
   - http://dbpedia.org/ontology/Genre
   - http://dbpedia.org/ontology/Band
+
 follow_references: false
+
+## Enable/disable generation of a default description for each schema
+default_descriptions: true
+
+## Enable/disable generation of default properties (description, id, label, and type) for each schema
+default_properties: true
 ```
 
 The result is available at: [DBPedia Music](https://app.swaggerhub.com/apis/mosoriob/dbpedia-music/v1.3.0)
-
 
 ### Following references
 
@@ -68,24 +74,23 @@ The option `follow_references` enables to follow the references.
 Let's enable the option for the previous example.
 
 Now, you have the whole information:
-- A city has 423 properties. 
-- One property is the leaderName and a leaderName is Person.
-- A person has 285. 
 
+- A city has 423 properties.
+- One property is the leaderName and a leaderName is Person.
+- A person has 285.
 
 !!! warning
-    For large ontologies, we don't recommend use the option because the result can be too heavy.
-
+For large ontologies, we don't recommend use the option because the result can be too heavy.
 
 ```yaml
 components:
   schemas:
     Band:
-        locationCity:
-          items:
-            $ref: '#/components/schemas/City'
-          nullable: true
-          type: array
+      locationCity:
+        items:
+          $ref: "#/components/schemas/City"
+        nullable: true
+        type: array
     City:
       properties:
         cityType:
@@ -100,7 +105,7 @@ components:
           type: array
         reffBourgmestre:
           items:
-            $ref: '#/components/schemas/Person'
+            $ref: "#/components/schemas/Person"
           nullable: true
           type: array
         communityIsoCode:
@@ -110,14 +115,14 @@ components:
           type: array
         leaderName:
           items:
-            $ref: '#/components/schemas/Person'
+            $ref: "#/components/schemas/Person"
           nullable: true
           type: array
     Person:
       properties:
         parent:
           items:
-            $ref: '#/components/schemas/Person'
+            $ref: "#/components/schemas/Person"
           nullable: true
           type: array
         viafId:
@@ -127,17 +132,92 @@ components:
           type: array
         competitionTitle:
           items:
-            $ref: '#/components/schemas/SportsEvent'
+            $ref: "#/components/schemas/SportsEvent"
           nullable: true
           type: array
         artPatron:
           items:
-            $ref: '#/components/schemas/Artist'
+            $ref: "#/components/schemas/Artist"
           nullable: true
           type: array
         hairColour:
           items:
             type: string
           nullable: true
-          type: array    
+          type: array
+```
+
+### Including default schema descriptions
+
+It is generally good practice to include a high-level description for a schema. By default, a placeholder description is included with the text `Description not available`. For example:
+
+```yaml
+components:
+  schemas:
+    YourClass:
+      description: Description not available
+      properties: {}
+      type: object
+```
+
+The option `default_descriptions` allows you to disable the default description for a schema (i.e. if there is no description/comment defined for an entity/class in the ontology). By setting the `default_descriptions` value to `false`, the above example becomes:
+
+```yaml
+components:
+  schemas:
+    YourClass:
+      properties: {}
+      type: object
+```
+
+### Including default schema properties
+
+You may wish to include common properties for each even if not defined for the entity/class. Currently, the default properites that are added to each schema are `description`, `id`, `label`, and `type`. For example:
+
+```yaml
+components:
+  schemas:
+    YourClass:
+      properties:
+        propertyA:
+          type: string
+        propertyB:
+          type: integer
+        description:
+          description: small description
+          items:
+            type: string
+          nullable: true
+          type: array
+        id:
+          description: identifier
+          nullable: false
+          type: string
+        label:
+          description: short description of the resource
+          items:
+            type: string
+          nullable: true
+          type: array
+        type:
+          description: type of the resource
+          items:
+            type: string
+          nullable: true
+          type: array
+      type: object
+```
+
+The option `default_properties` allows you to disable the default properties for a schema. If one or more of the properties are defined for the class, however, the property will still be included in the OpenAPI YAML specification. By setting the `default_properties` value to `false`, the above example becomes:
+
+```yaml
+components:
+  schemas:
+    YourClass:
+      properties:
+        propertyA:
+          type: string
+        propertyB:
+          type: integer
+      type: object
 ```

--- a/docs/filtering.md
+++ b/docs/filtering.md
@@ -172,7 +172,7 @@ components:
 
 ### Including default schema properties
 
-You may wish to include common properties for each even if not defined for the entity/class. Currently, the default properites that are added to each schema are `description`, `id`, `label`, and `type`. For example:
+You may wish to include common properties for each even if not defined for the entity/class. Currently, the default properites that are added to each schema are `description`, `id`, `label`, and `type`. Additional default properties are included (`eventDateTime`, `quantity`, `isBool`) which are meant to provide examples are other common data types. For example:
 
 ```yaml
 components:
@@ -183,24 +183,34 @@ components:
           type: string
         propertyB:
           type: integer
+        eventDateTime:
+          description: a date/time of the resource
+          format: date-time
+          nullable: true
+          type: string
+        quantity:
+          description: a number quantity of the resource
+          nullable: true
+          type: number
+        isBool:
+          description: a boolean indicator of the resource
+          nullable: true
+          type: boolean
         description:
           description: small description
-          items:
-            type: string
           nullable: true
-          type: array
-        id:
-          description: identifier
-          nullable: false
           type: string
         label:
           description: short description of the resource
-          items:
-            type: string
           nullable: true
-          type: array
+          type: string
+        id:
+          description: identifier
+          format: int32
+          nullable: false
+          type: integer
         type:
-          description: type of the resource
+          description: type(s) of the resource
           items:
             type: string
           nullable: true

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <packaging>jar</packaging>
     <groupId>edu.isi.oba</groupId>
     <artifactId>oba</artifactId>
-    <version>3.7.1</version>
+    <version>3.8.0</version>
     <name>core</name>
     <url>https://github.com/KnowledgeCaptureAndDiscovery/OBA</url>
 

--- a/src/main/java/edu/isi/oba/MapperDataProperty.java
+++ b/src/main/java/edu/isi/oba/MapperDataProperty.java
@@ -1,68 +1,64 @@
 package edu.isi.oba;
 
+import static edu.isi.oba.Oba.logger;
+
 import io.swagger.v3.oas.models.media.*;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static edu.isi.oba.Oba.logger;
-
 class MapperDataProperty {
-  private final HashMap<String, String> dataTypes;
-
-  private void setDataTypes() {
-    this.dataTypes.put("ENTITIES", "string");
-    this.dataTypes.put("ENTITY", "string");
-    this.dataTypes.put("ID", "string");
-    this.dataTypes.put("IDREF", "string");
-    this.dataTypes.put("IDREFS", "string");
-    this.dataTypes.put("NCName", "string");
-    this.dataTypes.put("NMTOKEN", "string");
-    this.dataTypes.put("NMTOKENS", "string");
-    this.dataTypes.put("NOTATION", "string");
-    this.dataTypes.put("Name", "string");
-    this.dataTypes.put("QName", "string");
-    this.dataTypes.put("anySimpleType", "string");
-    this.dataTypes.put("anyType", "string");
-    this.dataTypes.put("anyURI", "string");
-    this.dataTypes.put("base64Binary", "string");
-    this.dataTypes.put("boolean", "boolean");
-    this.dataTypes.put("byte", "integer");
-    this.dataTypes.put("date", "string");
-    this.dataTypes.put("dateTime", "dateTime");
-    this.dataTypes.put("dateTimeStamp", "dateTime");
-    this.dataTypes.put("decimal", "number");
-    this.dataTypes.put("double", "number");
-    this.dataTypes.put("duration", "string");
-    this.dataTypes.put("float", "number");
-    this.dataTypes.put("gDay", "string");
-    this.dataTypes.put("gMonth", "string");
-    this.dataTypes.put("gMonthYear", "string");
-    this.dataTypes.put("gYear", "string");
-    this.dataTypes.put("gYearMonth", "string");
-    this.dataTypes.put("hexBinary", "string");
-    this.dataTypes.put("int", "integer");
-    this.dataTypes.put("integer", "integer");
-    this.dataTypes.put("language", "string");
-    this.dataTypes.put("long", "integer");
-    this.dataTypes.put("negativeInteger", "integer");
-    this.dataTypes.put("nonNegativeInteger", "integer");
-    this.dataTypes.put("nonPositiveInteger", "integer");
-    this.dataTypes.put("normalizedString", "string");
-    this.dataTypes.put("positiveInteger", "integer");
-    this.dataTypes.put("short", "integer");
-    this.dataTypes.put("string", "string");
-    this.dataTypes.put("time", "string");
-    this.dataTypes.put("token", "string");
-    this.dataTypes.put("unsignedByte", "integer");
-    this.dataTypes.put("unsignedInt", "integer");
-    this.dataTypes.put("unsignedLong", "integer");
-    this.dataTypes.put("unsignedShort", "integer");
-    this.dataTypes.put("langString", "string");
-    this.dataTypes.put("Literal", "string");
-
-  }
+  private final Map<String, String> dataTypes = Map.ofEntries(
+    Map.entry("ENTITIES", "string"),
+    Map.entry("ENTITY", "string"),
+    Map.entry("ID", "string"),
+    Map.entry("IDREF", "string"),
+    Map.entry("IDREFS", "string"),
+    Map.entry("NCName", "string"),
+    Map.entry("NMTOKEN", "string"),
+    Map.entry("NMTOKENS", "string"),
+    Map.entry("NOTATION", "string"),
+    Map.entry("Name", "string"),
+    Map.entry("QName", "string"),
+    Map.entry("anySimpleType", "string"),
+    Map.entry("anyType", "string"),
+    Map.entry("anyURI", "string"),
+    Map.entry("base64Binary", "string"),
+    Map.entry("boolean", "boolean"),
+    Map.entry("byte", "integer"),
+    Map.entry("date", "string"),
+    Map.entry("dateTime", "dateTime"),
+    Map.entry("dateTimeStamp", "dateTime"),
+    Map.entry("decimal", "number"),
+    Map.entry("double", "number"),
+    Map.entry("duration", "string"),
+    Map.entry("float", "number"),
+    Map.entry("gDay", "string"),
+    Map.entry("gMonth", "string"),
+    Map.entry("gMonthYear", "string"),
+    Map.entry("gYear", "string"),
+    Map.entry("gYearMonth", "string"),
+    Map.entry("hexBinary", "string"),
+    Map.entry("int", "integer"),
+    Map.entry("integer", "integer"),
+    Map.entry("language", "string"),
+    Map.entry("long", "integer"),
+    Map.entry("negativeInteger", "integer"),
+    Map.entry("nonNegativeInteger", "integer"),
+    Map.entry("nonPositiveInteger", "integer"),
+    Map.entry("normalizedString", "string"),
+    Map.entry("positiveInteger", "integer"),
+    Map.entry("short", "integer"),
+    Map.entry("string", "string"),
+    Map.entry("time", "string"),
+    Map.entry("token", "string"),
+    Map.entry("unsignedByte", "integer"),
+    Map.entry("unsignedInt", "integer"),
+    Map.entry("unsignedLong", "integer"),
+    Map.entry("unsignedShort", "integer"),
+    Map.entry("langString", "string"),
+    Map.entry("Literal", "string")
+  );
 
   private String getDataType(String key){
     return this.dataTypes.get(key);
@@ -83,10 +79,7 @@ class MapperDataProperty {
   private Map<String,String> restrictions;
   private List<String> valuesFromDataRestrictions_ranges;
 
-
-  public MapperDataProperty(String name, String description, Boolean isFunctional,Map<String,String> restrictions,List<String> valuesFromDataRestrictions_ranges, List<String> type, Boolean array, Boolean nullable) {
-    this.dataTypes = new HashMap<>();
-    this.setDataTypes();
+  public MapperDataProperty(String name, String description, Boolean isFunctional, Map<String, String> restrictions, List<String> valuesFromDataRestrictions_ranges, List<String> type, Boolean array, Boolean nullable) {
     this.name = name;
     this.description = description;
     this.type = type;
@@ -135,40 +128,52 @@ class MapperDataProperty {
    */ 
   private ArraySchema composedSchema(List<String> base, boolean nullable){
 	  ArraySchema array = new ArraySchema();
-	  Schema schema ;
-	  ComposedSchema composedSchema = new ComposedSchema() ;
+	  Schema schema;
+	  ComposedSchema composedSchema = new ComposedSchema();
 	  array.setDescription(description);
-	  array.setNullable(nullable);  
+	  array.setNullable(nullable);
+
 	  // Operations for managing boolean combinations 
 	  for (String restriction:  restrictions.keySet()) { 
 		  String value = restrictions.get(restriction); 	  
-		  for (String item:base) {		  
+		  for (String item: base) {		  
 			  switch (getDataType(item)) {
 			  case STRING_TYPE:
 				  schema = new StringSchema();
-				  if (item.equals("anyURI"))
-					  schema.format("uri");
-				  else if (item.equals("byte"))
-					  schema.format("byte");
-				  break ;
+
+				  if (item.equals("anyURI")) {
+            schema.format("uri");
+          } else if (item.equals("byte")) {
+            schema.format("byte");
+          }
+
+				  break;
 			  case NUMBER_TYPE:
 				  schema = new NumberSchema();
-				  if (item.equals("float"))
-					  schema.format("float");
-				  else if (item.equals("double"))
-					  schema.format("double");
-				  break ;
+
+				  if (item.equals("float")) {
+            schema.format("double");
+          } else if (item.equals("double")) {
+            schema.format("double");
+          } else {
+            schema.format("number");
+          }
+          
+				  break;
 			  case INTEGER_TYPE:
 				  schema = new IntegerSchema();
-				  if (item.equals("long"))
-					  schema.format("int64");
-				  break ;
+
+				  if (item.equals("long")) {
+            schema.format("int64");
+          }
+					  
+				  break;
 			  case BOOLEAN_TYPE:
 				  schema = new BooleanSchema();
-				  break ;
+				  break;
 			  case DATETIME_TYPE:
 				  schema = new DateTimeSchema();
-				  break ;	       
+				  break;	       
 			  default:
 				  logger.warning("datatype mapping failed " + this.type.get(0));
 				  schema = new Schema();	  	
@@ -190,12 +195,15 @@ class MapperDataProperty {
 			  }
 		  }
 	  }
-	  array.setItems(composedSchema);  	 
 
-	  if (isFunctional)
-		  array.setMaxItems(1);
-	  array.setNullable(nullable);	     
-	  return array ;
+	  array.setItems(composedSchema);
+    array.setNullable(nullable);
+
+	  if (isFunctional) {
+      array.setMaxItems(1);
+    }
+	     
+	  return array;
   }
 
   private ArraySchema arraySchema(Schema base, boolean nullable) {

--- a/src/main/java/edu/isi/oba/MapperObjectProperty.java
+++ b/src/main/java/edu/isi/oba/MapperObjectProperty.java
@@ -1,8 +1,8 @@
 package edu.isi.oba;
 
-import io.swagger.v3.oas.models.media.*;
-
 import static edu.isi.oba.Oba.logger;
+
+import io.swagger.v3.oas.models.media.*;
 
 import java.util.LinkedHashSet;
 import java.util.List;

--- a/src/main/java/edu/isi/oba/MapperSchema.java
+++ b/src/main/java/edu/isi/oba/MapperSchema.java
@@ -288,8 +288,8 @@ class MapperSchema {
 		// Add some typical default properties (e.g. id, lable, type, and description)
         MapperDataProperty idProperty = new MapperDataProperty("id", "identifier", true, defaultRestrictionValues, valuesFromDataRestrictions_ranges, new ArrayList<String>(){{add("integer");}}, false, false);
         MapperDataProperty labelProperty = new MapperDataProperty("label", "short description of the resource", false, defaultRestrictionValues, valuesFromDataRestrictions_ranges, new ArrayList<String>(){{add("string");}}, false, true);
-        MapperDataProperty typeProperty = new MapperDataProperty("type", "type of the resource", false, defaultRestrictionValues, valuesFromDataRestrictions_ranges, new ArrayList<String>(){{add("string");}}, false, true);
-        MapperDataProperty descriptionProperty = new MapperDataProperty("description", "small description", false, defaultRestrictionValues, valuesFromDataRestrictions_ranges, new ArrayList<String>(){{add("string");}}, false, true);
+        MapperDataProperty typeProperty = new MapperDataProperty("type", "type(s) of the resource", false, defaultRestrictionValues, valuesFromDataRestrictions_ranges, new ArrayList<String>(){{add("string");}}, true, true);
+		MapperDataProperty descriptionProperty = new MapperDataProperty("description", "small description", false, defaultRestrictionValues, valuesFromDataRestrictions_ranges, new ArrayList<String>(){{add("string");}}, false, true);
 		
 		// Also add some default property examples of different types (e.g. a date/time, a boolean, and a float)
 		MapperDataProperty eventDateTimeProperty = new MapperDataProperty("eventDateTime", "a date/time of the resource", false, defaultRestrictionValues, valuesFromDataRestrictions_ranges, new ArrayList<String>(){{add("dateTime");}}, false, true);

--- a/src/main/java/edu/isi/oba/MapperSchema.java
+++ b/src/main/java/edu/isi/oba/MapperSchema.java
@@ -292,7 +292,7 @@ class MapperSchema {
         MapperDataProperty descriptionProperty = new MapperDataProperty("description", "small description", false, defaultRestrictionValues, valuesFromDataRestrictions_ranges, new ArrayList<String>(){{add("string");}}, false, true);
 		
 		// Also add some default property examples of different types (e.g. a date/time, a boolean, and a float)
-		MapperDataProperty eventDateTimeProperty = new MapperDataProperty("eventDateTime", "a date time of the resource", false, defaultRestrictionValues, valuesFromDataRestrictions_ranges, new ArrayList<String>(){{add("dateTime");}}, false, true);
+		MapperDataProperty eventDateTimeProperty = new MapperDataProperty("eventDateTime", "a date/time of the resource", false, defaultRestrictionValues, valuesFromDataRestrictions_ranges, new ArrayList<String>(){{add("dateTime");}}, false, true);
 		MapperDataProperty isBoolProperty = new MapperDataProperty("isBool", "a boolean indicator of the resource", false, defaultRestrictionValues, valuesFromDataRestrictions_ranges, new ArrayList<String>(){{add("boolean");}}, false, true);
 		MapperDataProperty quantityProperty = new MapperDataProperty("quantity", "a number quantity of the resource", false, defaultRestrictionValues, valuesFromDataRestrictions_ranges, new ArrayList<String>(){{add("float");}}, false, true);
 

--- a/src/main/java/edu/isi/oba/MapperSchema.java
+++ b/src/main/java/edu/isi/oba/MapperSchema.java
@@ -293,7 +293,7 @@ class MapperSchema {
 		
 		// Also add some default property examples of different types (e.g. a date/time, a boolean, and a float)
 		MapperDataProperty eventDateTimeProperty = new MapperDataProperty("eventDateTime", "a date time of the resource", false, defaultRestrictionValues, valuesFromDataRestrictions_ranges, new ArrayList<String>(){{add("dateTime");}}, false, true);
-		MapperDataProperty isBoolProperty = new MapperDataProperty("isGood", "a boolean indicator of the resource", false, defaultRestrictionValues, valuesFromDataRestrictions_ranges, new ArrayList<String>(){{add("boolean");}}, false, true);
+		MapperDataProperty isBoolProperty = new MapperDataProperty("isBool", "a boolean indicator of the resource", false, defaultRestrictionValues, valuesFromDataRestrictions_ranges, new ArrayList<String>(){{add("boolean");}}, false, true);
 		MapperDataProperty quantityProperty = new MapperDataProperty("quantity", "a number quantity of the resource", false, defaultRestrictionValues, valuesFromDataRestrictions_ranges, new ArrayList<String>(){{add("float");}}, false, true);
 
 		return Map.ofEntries(

--- a/src/main/java/edu/isi/oba/Oba.java
+++ b/src/main/java/edu/isi/oba/Oba.java
@@ -4,6 +4,7 @@ import edu.isi.oba.config.*;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.PathItem;
 import org.json.JSONObject;
+import org.openapitools.codegen.examples.ExampleGenerator;
 
 import java.io.*;
 import java.nio.file.Path;
@@ -66,30 +67,29 @@ class Oba {
     } else {
       config_data.setAuth(new AuthConfig());
     }
+
     try {
         Mapper mapper = new Mapper(config_data);
-        mapper.createSchemas(destination_dir, config_data);
+        mapper.createSchemas(destination_dir);
 
         LinkedHashMap<String, PathItem> custom_paths = config_data.getCustom_paths();
         OpenAPI openapi_base = config_data.getOpenapi();
         String custom_queries_dir = config_data.getCustom_queries_directory();
 
         //copy base project
-        ObaUtils.unZipIt(SERVERS_ZIP, destination_dir);
+        ObaUtils.unZipIt(Oba.SERVERS_ZIP, destination_dir);
         //get schema and paths
         generate_openapi_spec(openapi_base, mapper, destination_dir, custom_paths);
         generate_openapi_template(mapper, destination_dir, config_data, selected_language);
         generate_context(config_data, destination_dir);
         copy_custom_queries(custom_queries_dir, destination_dir);
-        logger.info("OBA finished successfully. Output can be found at: "+destination_dir);
-    }catch (Exception e){
-        logger.severe("Error while creating the API specification: "+e.getLocalizedMessage());
+        logger.info("OBA finished successfully. Output can be found at: " + destination_dir);
+    } catch (Exception e) {
+        logger.severe("Error while creating the API specification: " + e.getLocalizedMessage());
         e.printStackTrace();
         System.exit(1);
     }
   }
-
- 
   
   private static void generate_context(YamlConfig config_data, String destination_dir) {
     List<String> ontologies = config_data.getOntologies();
@@ -106,12 +106,12 @@ class Oba {
     try {
         ObaUtils.write_file(file_path, context_json_object.toString(4));
         ObaUtils.write_file(file_path_class, context_json_object_class.toString(4));
-    }catch(Exception e){
+    } catch(Exception e) {
         logger.severe("Could not generate the context files: "+e.getMessage());
     }
   }
 
-  private static void copy_custom_queries(String source, String destination){
+  private static void copy_custom_queries(String source, String destination) {
     if (source != null) {
       try {
         ObaUtils.copyFolder(new File(source), new File(destination + File.separator + "queries" + File.separator + "custom"));
@@ -140,10 +140,8 @@ class Oba {
                                             String dir,
                                             LinkedHashMap<String, PathItem> custom_paths
                                             ) throws Exception {
-    String destinationProjectDirectory = dir + File.separator + SERVERS_DIRECTORY;
+    String destinationProjectDirectory = dir + File.separator + Oba.SERVERS_DIRECTORY;
     Path destinationProject = Paths.get(destinationProjectDirectory);
     new Serializer(mapper, destinationProject, openapi_base, custom_paths);
   }
-
-
 }

--- a/src/main/java/edu/isi/oba/ObaUtils.java
+++ b/src/main/java/edu/isi/oba/ObaUtils.java
@@ -36,6 +36,7 @@ import org.yaml.snakeyaml.constructor.Constructor;
 import uk.ac.manchester.cs.owl.owlapi.OWLAnnotationPropertyImpl;
 
 public class ObaUtils {
+    public static final String DEFAULT_DESCRIPTION = "Description not available";
     public static final String[] POSSIBLE_VOCAB_SERIALIZATIONS = { "application/rdf+xml", "text/turtle", "text/n3",
 			"application/ld+json" };
     private static final String RDFS_NS = "http://www.w3.org/2000/01/rdf-schema#";
@@ -377,28 +378,31 @@ public class ObaUtils {
      * Method that given a class, property or data property, searches for the best description.
      * @param entity entity to search.
      * @param ontology ontology to be used to search descriptions.
+     * @param default_descriptions flag indicating whether default descriptions should or should not be included.
      * @return Description String (prioritizes English language)
      */
-    public static String getDescription(OWLEntity entity, OWLOntology ontology){
-        String descriptionValue = "Description not available";
-        for(String description:ObaUtils.DESCRIPTION_PROPERTIES){
-               Object[] annotationsObjects = EntitySearcher.getAnnotationObjects(entity, ontology, new OWLAnnotationPropertyImpl(new IRI(description) {
-               })).toArray();
-               if(annotationsObjects.length!=0){
-                   Optional<OWLLiteral> descriptionLiteral;
-                   for(Object annotation: annotationsObjects){
-                       descriptionLiteral = ((OWLAnnotation) annotation).getValue().asLiteral();
-                       if(descriptionLiteral.isPresent()){
-                           if(annotationsObjects.length == 1 || descriptionLiteral.get().getLang().equals("en")){
-                               descriptionValue = descriptionLiteral.get().getLiteral();
-                           }
-                       }
-                   }
-                   break;
-               }
-           }
-        return descriptionValue;
+    public static String getDescription(OWLEntity entity, OWLOntology ontology, Boolean default_descriptions) {
+        String descriptionValue = ObaUtils.DEFAULT_DESCRIPTION;
+        for (String description: ObaUtils.DESCRIPTION_PROPERTIES) {
+            Object[] annotationsObjects = EntitySearcher.getAnnotationObjects(entity, ontology, new OWLAnnotationPropertyImpl(new IRI(description){})).toArray();
+
+            if (annotationsObjects.length != 0) {
+                Optional<OWLLiteral> descriptionLiteral;
+                for (Object annotation: annotationsObjects) {
+                    descriptionLiteral = ((OWLAnnotation) annotation).getValue().asLiteral();
+
+                    if (descriptionLiteral.isPresent()) {
+                        if (annotationsObjects.length == 1 || descriptionLiteral.get().getLang().equals("en")) {
+                            descriptionValue = descriptionLiteral.get().getLiteral();
+                        }
+                    }
+                }
+
+                break;
+            }
+        }
+
+        return !Optional.ofNullable(default_descriptions).orElse(false) && ObaUtils.DEFAULT_DESCRIPTION.equals(descriptionValue) ? null : descriptionValue;
     }
-    
 }
 

--- a/src/main/java/edu/isi/oba/config/YamlConfig.java
+++ b/src/main/java/edu/isi/oba/config/YamlConfig.java
@@ -7,7 +7,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-
 public class YamlConfig {
   String DEFAULT_OUTPUT_DIRECTORY = "outputs";
   String DEFAULT_PROJECT_NAME = "default_project";
@@ -28,6 +27,8 @@ public class YamlConfig {
   private LinkedHashMap<String, PathItem> custom_paths = null;
   public List<String> classes;
   public Boolean follow_references = false;
+  public Boolean default_descriptions = true;
+  public Boolean default_properties = true;
 
   public Boolean getEnable_get_paths() {
     return enable_get_paths;
@@ -158,6 +159,22 @@ public class YamlConfig {
 
   public void setFollow_references(Boolean follow_references) {
     this.follow_references = follow_references;
+  }
+
+  public Boolean getDefault_descriptions() {
+    return this.default_descriptions;
+  }
+
+  public void setDefault_descriptions(Boolean default_descriptions) {
+    this.default_descriptions = default_descriptions;
+  }
+
+  public Boolean getDefault_properties() {
+    return this.default_properties;
+  }
+
+  public void setDefault_properties(Boolean default_properties) {
+    this.default_properties = default_properties;
   }
 
   public AuthConfig getAuth() {

--- a/src/test/java/edu/isi/oba/MapperTest.java
+++ b/src/test/java/edu/isi/oba/MapperTest.java
@@ -112,8 +112,8 @@ public class MapperTest {
         config_data.setAuth(new AuthConfig());
         Mapper mapper = new Mapper(config_data);
         OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://businessontology.com/ontology/Person");
-        String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0));
-        MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true);
+        String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0), true);
+        MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true, true, true);
         Schema schema = mapperSchema.getSchema();
         // The person schema must not be null.
         Assertions.assertNotNull(schema);

--- a/src/test/java/edu/isi/oba/ObaUtilsTest.java
+++ b/src/test/java/edu/isi/oba/ObaUtilsTest.java
@@ -53,7 +53,7 @@ public class ObaUtilsTest {
         try {
             Mapper mapper = new Mapper(config_data);
             OWLClass planClass = mapper.manager.getOWLDataFactory().getOWLClass("http://purl.org/net/p-plan#Plan");
-            String desc = ObaUtils.getDescription(planClass, mapper.ontologies.get(0));
+            String desc = ObaUtils.getDescription(planClass, mapper.ontologies.get(0), true);
             Assertions.assertNotEquals(desc, "");
         }catch(Exception e){
             Assertions.fail("Failed to get description.", e);

--- a/src/test/java/edu/isi/oba/RestrictionsTest.java
+++ b/src/test/java/edu/isi/oba/RestrictionsTest.java
@@ -55,8 +55,8 @@ public class RestrictionsTest {
 			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
 			Mapper mapper = new Mapper(config_data);
 			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#University");
-			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0));
-			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true);
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0), true);
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true, true, true);
 			Schema schema = mapperSchema.getSchema();	  	       
 			Object property= schema.getProperties().get("hasRector");	       	        
 			if (property instanceof io.swagger.v3.oas.models.media.ArraySchema) {	        	
@@ -81,8 +81,8 @@ public class RestrictionsTest {
 			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
 			Mapper mapper = new Mapper(config_data);
 			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#StudyMaterial");
-			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0));
-			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true);
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0), true);
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true, true, true);
 			Schema schema = mapperSchema.getSchema();	  	       
 			Object property= schema.getProperties().get("author");		        
 			if (property instanceof ArraySchema) {	
@@ -115,8 +115,8 @@ public class RestrictionsTest {
 			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
 			Mapper mapper = new Mapper(config_data);
 			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#Course");
-			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0));
-			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true);
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0), true);
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true, true, true);
 			Schema schema = mapperSchema.getSchema();	  	       
 			Object property= schema.getProperties().get("hasEvaluationMethod");		        
 			if (property instanceof ArraySchema) {	
@@ -147,8 +147,8 @@ public class RestrictionsTest {
 			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
 			Mapper mapper = new Mapper(config_data);
 			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#University");
-			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0));
-			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true);
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0), true);
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true, true, true);
 			Schema schema = mapperSchema.getSchema();	  	       
 			Object property= schema.getProperties().get("hasDepartment");		        
 			if (property instanceof ArraySchema) {	
@@ -175,8 +175,8 @@ public class RestrictionsTest {
 			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
 			Mapper mapper = new Mapper(config_data);
 			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#Student");
-			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0));
-			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true);
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0), true);
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true, true, true);
 			Schema schema = mapperSchema.getSchema();	  	       
 			Object property= schema.getProperties().get("enrolledIn");		        
 			if (property instanceof ArraySchema) {	
@@ -207,8 +207,8 @@ public class RestrictionsTest {
 			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
 			Mapper mapper = new Mapper(config_data);
 			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#AmericanStudent");
-			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0));
-			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true);
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0), true);
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true, true, true);
 			Schema schema = mapperSchema.getSchema();	  	       
 			Object property= schema.getProperties().get("hasRecord");		        
 			if (property instanceof ArraySchema) {					
@@ -239,8 +239,8 @@ public class RestrictionsTest {
 			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
 			Mapper mapper = new Mapper(config_data);
 			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#AmericanStudent");
-			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0));
-			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true);
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0), true);
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true, true, true);
 			Schema schema = mapperSchema.getSchema();	  	       
 			Object property= schema.getProperties().get("takesCourse");		        
 			if (property instanceof ArraySchema) {									
@@ -268,8 +268,8 @@ public class RestrictionsTest {
 			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
 			Mapper mapper = new Mapper(config_data);
 			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#Course");
-			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0));
-			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true);
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0), true);
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true, true, true);
 			Schema schema = mapperSchema.getSchema();	  	       
 			Object property= schema.getProperties().get("hasStudentEnrolled");		        
 			if (property instanceof ArraySchema) {									
@@ -299,8 +299,8 @@ public class RestrictionsTest {
 			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
 			Mapper mapper = new Mapper(config_data);
 			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#ProfessorInOtherDepartment");
-			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0));
-			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true);
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0), true);
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true, true, true);
 			Schema schema = mapperSchema.getSchema();	
 			if (schema.getNot()!=null)
 				Assertions.assertEquals(schema.getNot().get$ref(),expectedResult);				
@@ -323,8 +323,8 @@ public class RestrictionsTest {
 			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
 			Mapper mapper = new Mapper(config_data);
 			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#ProfessorInArtificialIntelligence");
-			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0));
-			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true);
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0), true);
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true, true, true);
 			Schema schema = mapperSchema.getSchema();	  	       
 			Object property= schema.getProperties().get("belongsTo");	
 			if (((ObjectSchema) property).getDefault()!=null)
@@ -350,8 +350,8 @@ public class RestrictionsTest {
 			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
 			Mapper mapper = new Mapper(config_data);
 			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#Professor");
-			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0));
-			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true);
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0), true);
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true, true, true);
 			Schema schema = mapperSchema.getSchema();	  	       
 			Object property= schema.getProperties().get("hasDegree");		        
 
@@ -384,8 +384,8 @@ public class RestrictionsTest {
 			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
 			Mapper mapper = new Mapper(config_data);
 			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#AmericanStudent");
-			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0));
-			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true);
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0), true);
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true, true, true);
 			Schema schema = mapperSchema.getSchema();	  	       
 			Object property= schema.getProperties().get("birthDate");	       	        
 			if (property instanceof io.swagger.v3.oas.models.media.ArraySchema) {	        	
@@ -411,8 +411,8 @@ public class RestrictionsTest {
 			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
 			Mapper mapper = new Mapper(config_data);
 			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#Course");
-			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0));
-			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true);
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0), true);
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true, true, true);
 			Schema schema = mapperSchema.getSchema();	  	       
 			Object property= schema.getProperties().get("ects");		        
 			if (property instanceof ArraySchema) {	
@@ -445,8 +445,8 @@ public class RestrictionsTest {
 			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
 			Mapper mapper = new Mapper(config_data);
 			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#ProfessorInArtificialIntelligence");
-			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0));
-			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true);
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0), true);
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true, true, true);
 			Schema schema = mapperSchema.getSchema();	  	       
 			Object property= schema.getProperties().get("memberOfOtherDepartments");		        
 			if (property instanceof ArraySchema) {	
@@ -477,8 +477,8 @@ public class RestrictionsTest {
 			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
 			Mapper mapper = new Mapper(config_data);
 			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#StudyProgram");
-			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0));
-			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true);
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0), true);
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true, true, true);
 			Schema schema = mapperSchema.getSchema();	  	       
 			Object property= schema.getProperties().get("studyProgramName");		        
 			if (property instanceof ArraySchema) {	
@@ -505,8 +505,8 @@ public class RestrictionsTest {
 			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
 			Mapper mapper = new Mapper(config_data);
 			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#ProfessorInArtificialIntelligence");
-			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0));
-			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true);
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0), true);
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true, true, true);
 			Schema schema = mapperSchema.getSchema();	  	       
 			Object property= schema.getProperties().get("memberOfOtherDepartments");		        
 			if (property instanceof ArraySchema) {	
@@ -537,8 +537,8 @@ public class RestrictionsTest {
 			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
 			Mapper mapper = new Mapper(config_data);
 			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#StudyProgram");
-			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0));
-			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true);
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0), true);
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true, true, true);
 			Schema schema = mapperSchema.getSchema();	  	       
 			Object property= schema.getProperties().get("studyProgramName");		        
 			if (property instanceof ArraySchema) {	
@@ -562,8 +562,8 @@ public class RestrictionsTest {
 			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
 			Mapper mapper = new Mapper(config_data);
 			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#Person");
-			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0));
-			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true);
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0), true);
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true, true, true);
 			Schema schema = mapperSchema.getSchema();	  	       
 			Object property= schema.getProperties().get("gender");	
 			if (property instanceof ArraySchema) {	
@@ -595,8 +595,8 @@ public class RestrictionsTest {
 			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
 			Mapper mapper = new Mapper(config_data);
 			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#AmericanStudent");
-			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0));
-			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true);
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0), true);
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true, true, true);
 			Schema schema = mapperSchema.getSchema();	  	       
 			Object property= schema.getProperties().get("nationality");	
 			
@@ -620,8 +620,8 @@ public class RestrictionsTest {
 			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
 			Mapper mapper = new Mapper(config_data);
 			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#University");
-			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0));
-			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true);
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0), true);
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true, true, true);
 			Schema schema = mapperSchema.getSchema();	  	       
 			Object property= schema.getProperties().get("universityName");		        					
 				Integer maxItems = ((ArraySchema) property).getItems().getMaxItems();
@@ -649,8 +649,8 @@ public class RestrictionsTest {
 			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
 			Mapper mapper = new Mapper(config_data);
 			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#Professor");
-			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0));
-			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true);
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0), true);
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true, true, true);
 			Schema schema = mapperSchema.getSchema();	  	       
 			Object property= schema.getProperties().get("researchField");		        					
 			Integer minItems = ((ArraySchema) property).getItems().getMinItems();
@@ -675,8 +675,8 @@ public class RestrictionsTest {
 			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
 			Mapper mapper = new Mapper(config_data);
 			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#Person");
-			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0));
-			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true);
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0), true);
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true, true, true);
 			Schema schema = mapperSchema.getSchema();	  	       
 			Object property= schema.getProperties().get("address");		        					
 			Integer maxItems = ((ArraySchema) property).getItems().getMaxItems();
@@ -701,8 +701,8 @@ public class RestrictionsTest {
 			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
 			Mapper mapper = new Mapper(config_data);
 			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#Department");
-			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0));
-			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true);
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0), true);
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), true, true, true);
 			Schema schema = mapperSchema.getSchema();	
 			Object property= schema.getProperties().get("numberOfProfessors");				
 			if (((ArraySchema) property).getItems().getNot()!=null)


### PR DESCRIPTION
I was not interested in see all the default descriptions and properties that were automatically added to schemas.  Therefore, I added a flag to the config file for each of them so that they can be disabled, if desired.  I kept them set to `true` by default so that the original behavior is to include them.

Updated the documentation (`configuration_file.md` and `filtering.md`) to include show usage and provide some examples of with/without the options enabled.  These markdown files were automatically reformatted by my editor, so there are extra changes, mostly related to whitespace.

For the default properties, I added a few so that more types (e.g. boolean, date/time, and float/number) were available.  Not sure if this is desired.  However, because these properties were just placeholders anyway, I thought it might be useful to see examples of something other than strings.

I left the `type` default property as an array, but it seemed unnecessary for all of them to be arrays.  It looked a bit junky to have an array of items where the item was just one string.  I understand this could be a use case, but that's why I opted to leave it for one of the properties.

Some assorted formatting cleanup also.