### PR TITLE
Proper pluralization for paths

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <packaging>jar</packaging>
     <groupId>edu.isi.oba</groupId>
     <artifactId>oba</artifactId>
-    <version>3.9.0</version>
+    <version>3.9.1</version>
     <name>core</name>
     <url>https://github.com/KnowledgeCaptureAndDiscovery/OBA</url>
 
@@ -16,7 +16,7 @@
         <maven.compiler.release>11</maven.compiler.release>
         <jdk.version>11</jdk.version>
         <!-- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-shade-plugin -->
-        <maven-shade-plugin.version>3.5.2</maven-shade-plugin.version>
+        <maven-shade-plugin.version>3.5.3</maven-shade-plugin.version>
     </properties>
 
     <dependencies>
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-compat-spec-parser</artifactId>
-            <version>1.0.70</version>
+            <version>1.0.71</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/io.swagger.core.v3/swagger-models -->
         <dependency>
@@ -51,20 +51,20 @@
         <dependency>
             <groupId>io.swagger.parser.v3</groupId>
             <artifactId>swagger-parser</artifactId>
-            <version>2.1.21</version>
+            <version>2.1.22</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/io.swagger.parser.v3/swagger-parser-core -->
         <dependency>
             <groupId>io.swagger.parser.v3</groupId>
             <artifactId>swagger-parser-core</artifactId>
-            <version>2.1.21</version>
+            <version>2.1.22</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.openapitools/openapi-generator -->
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>openapi-generator</artifactId>
-            <version>7.4.0</version>
+            <version>7.5.0</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/net.sourceforge.owlapi/owlapi-api -->
@@ -97,7 +97,7 @@
         <dependency>
             <groupId>commons-cli</groupId>
             <artifactId>commons-cli</artifactId>
-            <version>1.6.0</version>
+            <version>1.7.0</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-core -->
@@ -105,7 +105,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.17.0</version>
+            <version>2.17.1</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.jibx/jibx-tools -->

--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,13 @@
             <artifactId>jackson-core</artifactId>
             <version>2.17.0</version>
         </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.jibx/jibx-tools -->
+        <dependency>
+            <groupId>org.jibx</groupId>
+            <artifactId>jibx-tools</artifactId>
+            <version>1.4.2</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/edu/isi/oba/Mapper.java
+++ b/src/main/java/edu/isi/oba/Mapper.java
@@ -17,6 +17,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
+import org.jibx.schema.codegen.extend.DefaultNameConverter;
+import org.jibx.schema.codegen.extend.NameConverter;
 import org.semanticweb.owlapi.apibinding.OWLManager;
 import org.semanticweb.owlapi.io.FileDocumentSource;
 import org.semanticweb.owlapi.model.*;
@@ -249,13 +251,18 @@ class Mapper {
     }
 
     private void add_path(PathGenerator pathGenerator, MapperSchema mapperSchema) {
-        String singular_name = "/" + mapperSchema.name.toLowerCase() + "s/{id}";
-        String plural_name = "/" + mapperSchema.name.toLowerCase() + "s";
+        // Pluralizing currently only works for English.  Non-English words will be treated as though they are English.
+        // TODO: Java support for singularization/pluralization and locale/international support supoort for the process does not have many good options that we could find so far.
+        // TODO: If such an option exists or becomes available, this should be updated to support pluralization in other languages.
+        // TODO: The language/locale would need to be set as a configuration value and passed into this class somehow.
+        NameConverter nameTools = new DefaultNameConverter();
+        String plural_name = "/" + nameTools.pluralize(mapperSchema.name.toLowerCase());
+
         //Create the plural paths: for example: /models/
         this.paths.addPathItem(plural_name, pathGenerator.generate_plural(mapperSchema.name,
                 mapperSchema.getCls().getIRI().getIRIString()));
         //Create the plural paths: for example: /models/id
-        this.paths.addPathItem(singular_name, pathGenerator.generate_singular(mapperSchema.name,
+        this.paths.addPathItem(plural_name + "/{id}", pathGenerator.generate_singular(mapperSchema.name,
                 mapperSchema.getCls().getIRI().getIRIString()));
     }
 


### PR DESCRIPTION
The existing pluralization is basically a rubber stamp method of adding `s` onto the word.  I noticed this pluralizes words which have a different pluralization requirement, such as `University`, incorrectly (e.g. `Universitys`).  It also supports other less-common pluralization, such as `sex`/`sexes`, `ox`/`oxen`, etc.

This can be corrected manually after OpenAPI generation for small ontologies.  But it is unwieldy for larger ones.

Upon investigating tools that we could use to pluralize, I was shocked that Java does not support this well compared to many other programming/scripting languages.  I could only find ones that handle English, and there were only a few tools available (some have not been updated for many years).  Because it was currently only adding `s`, and I assume it was English-centric for this purpose(?), I settled with JiBX tools.  JiBX tools was updated as recently as late 2022.