### PR TITLE
Restriction visitor rewrite supports most complex restrictions.  Change most lists to sets.  Some mapper updates to deal with those changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <packaging>jar</packaging>
     <groupId>edu.isi.oba</groupId>
     <artifactId>oba</artifactId>
-    <version>3.9.1</version>
+    <version>3.10.0</version>
     <name>core</name>
     <url>https://github.com/KnowledgeCaptureAndDiscovery/OBA</url>
 

--- a/src/main/java/edu/isi/oba/MapperObjectProperty.java
+++ b/src/main/java/edu/isi/oba/MapperObjectProperty.java
@@ -4,50 +4,50 @@ import static edu.isi.oba.Oba.logger;
 
 import io.swagger.v3.oas.models.media.*;
 
-import java.util.LinkedHashSet;
-import java.util.List;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
-import java.util.stream.Collectors;
+import java.util.Set;
 
 class MapperObjectProperty {
   final String name;
   final String description;
-  private List<String> ref;
+  final private Set<String> ref;
   private Boolean array;
   private Boolean nullable;
   final Boolean isFunctional;
   
-  final Map<String,String>  restrictions;
+  final Map<String,String> restrictions;
 
-  public MapperObjectProperty(String name, String description, Boolean isFunctional, Map<String,String> restrictions, List<String> ref) {
+  public MapperObjectProperty(String name, String description, Boolean isFunctional, Map<String,String> restrictions, Set<String> ref) {
     this.name = name;
     this.description = description;
-    this.ref = ref;
+    this.ref = (ref != null) ? ref : new HashSet<>();
     this.array = true;
     this.nullable = true;
     this.isFunctional = isFunctional;
-    this.restrictions = restrictions;
+    this.restrictions = (restrictions != null) ? restrictions : new HashMap<>();
   }
 
-  public MapperObjectProperty(String name, String description,  Boolean isFunctional, Map<String,String> restrictions, List<String> ref, Boolean array, Boolean nullable) {
+  public MapperObjectProperty(String name, String description,  Boolean isFunctional, Map<String, String> restrictions, Set<String> ref, Boolean array, Boolean nullable) {
     this.name = name;
     this.description = description;
-    this.ref = ref;
+    this.ref = (ref != null) ? ref : new HashSet<>();
     this.array = array;
     this.nullable = nullable;
     this.isFunctional = isFunctional;
-    this.restrictions = restrictions;
+    this.restrictions = (restrictions != null) ? restrictions : new HashMap<>();
   }
 
   public Schema getSchemaByObjectProperty() {
-    if (this.ref.isEmpty()){
+    if (this.ref == null || this.ref.isEmpty()){
       return getComposedSchemaObject(this.ref, this.array, this.nullable);
     }
 
     if (this.ref.size() > 1){
       return getComposedSchemaObject(this.ref, this.array, this.nullable);
     } else {
-      return getObjectPropertiesByRef(this.ref.get(0), this.array, this.nullable);
+      return getObjectPropertiesByRef(this.ref.iterator().next(), this.array, this.nullable);
     }
   }
 
@@ -147,14 +147,14 @@ class MapperObjectProperty {
     return objects;
   }
 
-  private Schema getComposedSchemaObject(List<String> refs, boolean array, boolean nullable) {
+  private Schema getComposedSchemaObject(Set<String> refs, boolean array, boolean nullable) {
     Schema object = new ObjectSchema();
     ComposedSchema composedSchema = new ComposedSchema();
     
     object.setType("object");
     object.setDescription(this.description);
 
-    if (array && !this.restrictions.isEmpty()) {
+    if (array) {
     	ArraySchema objects = new ArraySchema();
     	objects.setDescription(this.description);
     	
@@ -165,10 +165,7 @@ class MapperObjectProperty {
     	for (String restriction:  this.restrictions.keySet()) { 
         String value = this.restrictions.get(restriction);
 
-        // In some cases, the duplicate reference may have been added to the list.  We only need to create one $ref item to it.
-        LinkedHashSet<String> uniqueRefs = refs.stream().collect(Collectors.toCollection(LinkedHashSet::new));
-
-    		for (String item: uniqueRefs) {
+        for (String item: refs) {
     			Schema objectRange = new ObjectSchema();
     			objectRange.setType("object");
     			objectRange.set$ref(item);
@@ -176,37 +173,66 @@ class MapperObjectProperty {
     			switch (restriction) {
     			case "unionOf":
     				if ("someValuesFrom".equals(value)) {
-    					nullable=false;
+    					nullable = false;
             }
 
-    				composedSchema.addAnyOfItem(objectRange);
-    				objects.setItems(composedSchema);
+            if (composedSchema.getAnyOf() == null || !composedSchema.getAnyOf().contains(objectRange)) {
+              composedSchema.addAnyOfItem(objectRange);
+              objects.setItems(composedSchema);
+            }
+    				
     				break;
     			case "intersectionOf":
     				if ("someValuesFrom".equals(value)) {
     					nullable = false;
             }
 
-    				composedSchema.addAllOfItem(objectRange);
-    				objects.setItems(composedSchema);
+            if (composedSchema.getAllOf() == null || !composedSchema.getAllOf().contains(objectRange)) {
+              composedSchema.addAllOfItem(objectRange);
+              objects.setItems(composedSchema);
+            }
+
     				break;
     			case "someValuesFrom":
-    				nullable=false;
-            composedSchema.addAnyOfItem(objectRange);
-            objects.setItems(composedSchema);
+    				nullable = false;
+
+            if (composedSchema.getAnyOf() == null || !composedSchema.getAnyOf().contains(objectRange)) {
+              composedSchema.addAnyOfItem(objectRange);
+              objects.setItems(composedSchema);
+            }
+
     				break;
     			case "allValuesFrom":
     				//nothing to do in the Schema
     				break;
     	    case "oneOf":
-            if (value=="someValuesFrom") {
-              nullable=false;
+            if ("someValuesFrom".equals(value)) {
+              nullable = false;
             }
 
-            composedSchema.addEnumItemObject(item);
-            composedSchema.setType("string");
-            composedSchema.setFormat("uri");
+            Schema enumSchema = new Schema();
+
+            if (composedSchema.getOneOf() == null || composedSchema.getOneOf().isEmpty()) {
+              enumSchema.addEnumItemObject(item);
+            } else {
+              enumSchema = composedSchema.getOneOf().iterator().next();
+              enumSchema.addEnumItemObject(item);
+              composedSchema = new ComposedSchema();
+            }
+
+            composedSchema.addOneOfItem(enumSchema);
+
             objects.setItems(composedSchema);
+            break;
+          case "maxCardinality":
+            objects.setMaxItems(Integer.parseInt(value));
+            break;
+          case "minCardinality":
+            objects.setMinItems(Integer.parseInt(value));
+            break;
+          case "exactCardinality":
+            objects.setMaxItems(Integer.parseInt(value));
+            objects.setMinItems(Integer.parseInt(value));
             break;
     			default:
     				//if the property range is complex it will be omitted   
@@ -216,10 +242,18 @@ class MapperObjectProperty {
     		}
     	}
 
+      objects.setNullable(nullable);
+
     	if (refs.isEmpty()) {
-        objects.setItems(object);
+        if (objects.getItems() != null && objects.getEnum() != null) {
+          objects.setItems(object);
+        } else {
+          objects.setType(null);
+          objects.setDescription(null);
+          objects.setItems(null);
+          objects.setNullable(null);
+        }
       }
-    	objects.setNullable(nullable);
 
     	return objects;
     } else {

--- a/src/main/java/edu/isi/oba/Oba.java
+++ b/src/main/java/edu/isi/oba/Oba.java
@@ -93,7 +93,7 @@ class Oba {
   }
   
   private static void generate_context(YamlConfig config_data, String destination_dir) {
-    List<String> ontologies = config_data.getOntologies();
+    Set<String> ontologies = config_data.getOntologies();
     JSONObject context_json_object = null;
     JSONObject context_json_object_class = null;
     try {

--- a/src/main/java/edu/isi/oba/RestrictionVisitor.java
+++ b/src/main/java/edu/isi/oba/RestrictionVisitor.java
@@ -80,7 +80,7 @@ public class RestrictionVisitor implements OWLObjectVisitor {
 
 	@Override
 	public void visit( OWLEquivalentClassesAxiom ce ) {
-		logger.info("Analyzing restrictions of Class: " + this.cls+ " with axiom: "+ce);
+		logger.info("Analyzing restrictions of Class: " + this.cls + " with axiom: " + ce);
 
 		// If equivalent class axiom AND contains owl:oneOf, then we're looking at an ENUM class.
 		ce.classExpressions().filter((e) -> e instanceof OWLObjectOneOf).forEach((oneOfObj) -> {
@@ -143,9 +143,9 @@ public class RestrictionVisitor implements OWLObjectVisitor {
 	 */
 	@Override
 	public void visit(OWLObjectAllValuesFrom ce) {
-		logger.info("Analyzing restrictions of Class: " + this.cls+ " with axiom: "+ce);
+		logger.info("Analyzing restrictions of Class: " + this.cls + " with axiom: " + ce);
 		Map<String, String> restrictionsValues = new HashMap<>();
-		for (OWLObjectProperty property:ce.getObjectPropertiesInSignature()) {
+		for (OWLObjectProperty property: ce.getObjectPropertiesInSignature()) {
 			propertiesFromObjectRestrictions.add(property);
 			property_name = sfp.getShortForm(property.getIRI());
 		}
@@ -168,45 +168,45 @@ public class RestrictionVisitor implements OWLObjectVisitor {
 		
 	@Override
 	public void visit(OWLObjectUnionOf ce) {
-		logger.info("Analyzing restrictions of Class: " + this.cls+ " with axiom: "+ce);
+		logger.info("Analyzing restrictions of Class: " + this.cls + " with axiom: " + ce);
 		
 		// Loop through each item in the union and accept visits.
-		for (OWLClassExpression e : ce.getOperands()) {
+		for (OWLClassExpression e: ce.getOperands()) {
 			e.accept(this);
 		}
 	}
 
 	@Override
 	public void visit(OWLObjectIntersectionOf ce) {
-		logger.info("Analyzing restrictions of Class: " + this.cls+ " with axiom: "+ce);
+		logger.info("Analyzing restrictions of Class: " + this.cls + " with axiom: " + ce);
 		
 		// Loop through each item in the intersection and accept visits.
-		for (OWLClassExpression e : ce.getOperands()) {
+		for (OWLClassExpression e: ce.getOperands()) {
 			e.accept(this);
 		}
 	}
 
 	@Override
 	public void visit(OWLObjectMinCardinality ce) {
-		logger.info("Analyzing restrictions of Class: " + this.cls+ " with axiom: "+ce);
+		logger.info("Analyzing restrictions of Class: " + this.cls + " with axiom: " + ce);
 		setPropertiesWithCardinality(ce, "minCardinality");
 	}
 
 	@Override
 	public void visit(OWLObjectMaxCardinality ce) {
-		logger.info("Analyzing restrictions of Class: " + this.cls+ " with axiom: "+ce);
+		logger.info("Analyzing restrictions of Class: " + this.cls + " with axiom: " + ce);
 		setPropertiesWithCardinality(ce,"maxCardinality");
 	}
 
 	@Override
 	public void visit(OWLObjectExactCardinality ce) {
-		logger.info("Analyzing restrictions of Class: " + this.cls+ " with axiom: "+ce);
+		logger.info("Analyzing restrictions of Class: " + this.cls + " with axiom: " + ce);
 		setPropertiesWithCardinality(ce, "exactCardinality");
 	}
 	
 	@Override
 	public void visit(OWLObjectComplementOf ce) {
-		logger.info("Analyzing restrictions of Class: " + this.cls+ " with axiom: "+ce);
+		logger.info("Analyzing restrictions of Class: " + this.cls + " with axiom: " + ce);
 		Map<String, String> restrictionsValues = new HashMap<String, String>();
 		String complementName = this.sfp.getShortForm(ce.getOperand().asOWLClass().getIRI());
 		restrictionsValues.put("complementOf", complementName );
@@ -267,9 +267,9 @@ public class RestrictionVisitor implements OWLObjectVisitor {
 	 */
 	@Override
 	public void visit(OWLDataAllValuesFrom ce) {
-		logger.info( "\n Analyzed Class: " + this.cls+ " with axiom: "+ce);
+		logger.info( "\n Analyzed Class: " + this.cls + " with axiom: " + ce);
 		Map<String, String> restrictionsValues = new HashMap<String, String>();
-		for (OWLDataProperty property:ce.getDataPropertiesInSignature()) {
+		for (OWLDataProperty property: ce.getDataPropertiesInSignature()) {
 			propertiesFromDataRestrictions.add(property);
 			property_name = sfp.getShortForm(property.getIRI());
 		}
@@ -325,39 +325,39 @@ public class RestrictionVisitor implements OWLObjectVisitor {
 
 	@Override
 	public void visit(OWLDataUnionOf ce) {
-		logger.info("Analyzing restrictions of Class: " + this.cls+ " with axiom: "+ce);
+		logger.info("Analyzing restrictions of Class: " + this.cls + " with axiom: " + ce);
 		
 		// Loop through each item in the union and accept visits.
-		for (OWLDataRange e : ce.getOperands()) {
+		for (OWLDataRange e: ce.getOperands()) {
 			e.accept(this);
 		}
 	}
 	
 	@Override
 	public void visit(OWLDataIntersectionOf ce) {
-		logger.info("Analyzing restrictions of Class: " + this.cls+ " with axiom: "+ce);
+		logger.info("Analyzing restrictions of Class: " + this.cls + " with axiom: " + ce);
 
 		// Loop through each item in the intersection and accept visits.
-		for (OWLDataRange e : ce.getOperands()) {
+		for (OWLDataRange e: ce.getOperands()) {
 			e.accept(this);
 		}
 	}
 	
 	@Override
 	public void visit(OWLDataMinCardinality ce) {
-		logger.info("Analyzing restrictions of Class: " + this.cls+ " with axiom: "+ce);
+		logger.info("Analyzing restrictions of Class: " + this.cls + " with axiom: " + ce);
 		setDataPropertiesWithCardinality(ce,"minCardinality");
 	}
 	
 	@Override
 	public void visit(OWLDataMaxCardinality ce) {
-		logger.info("Analyzing restrictions of Class: " + this.cls+ " with axiom: "+ce);
+		logger.info("Analyzing restrictions of Class: " + this.cls + " with axiom: " + ce);
 		setDataPropertiesWithCardinality(ce,"maxCardinality");
 	}
 	
 	@Override
 	public void visit(OWLDataExactCardinality ce) {
-		logger.info("Analyzing restrictions of Class: " + this.cls+ " with axiom: "+ce);
+		logger.info("Analyzing restrictions of Class: " + this.cls + " with axiom: " + ce);
 		setDataPropertiesWithCardinality(ce,"exactCardinality");
 	}
 	
@@ -416,7 +416,7 @@ public class RestrictionVisitor implements OWLObjectVisitor {
 		String property_name = "";
 		List<String> ranges = new ArrayList<String>();
 		Map<String, String> restrictionsValues = new HashMap<String, String>();
-		for (OWLObjectProperty property:ce.getObjectPropertiesInSignature()) {
+		for (OWLObjectProperty property: ce.getObjectPropertiesInSignature()) {
 			propertiesFromObjectRestrictions.add(property);
 			property_name = sfp.getShortForm(property.getIRI());
 			ranges.add(sfp.getShortForm(ce.getFiller().asOWLClass().getIRI()));
@@ -439,7 +439,7 @@ public class RestrictionVisitor implements OWLObjectVisitor {
 		Map<String, String> restrictionsValues = new HashMap<String, String>();
 		//if the expression ce is not part of a composed expression (existential or universal)
 		if (property_name.isEmpty()) {
-			for (OWLObjectProperty property:properties) {
+			for (OWLObjectProperty property: properties) {
 				propertiesFromObjectRestrictions.add(property);
 				property_name = sfp.getShortForm(property.getIRI());
 				restrictionsValues.put(restriction, "");
@@ -447,7 +447,7 @@ public class RestrictionVisitor implements OWLObjectVisitor {
 			}
 		} else {
 			List<String> rangeList = new ArrayList<String>();
-			for (OWLClassExpression range:ranges) {
+			for (OWLClassExpression range: ranges) {
 				rangeList.add(sfp.getShortForm(range.asOWLClass().getIRI()));
 				if (range.asOWLClass().equals(owlThing)) {
 					logger.info("Ignoring owl:Thing range" + property_name);
@@ -460,7 +460,7 @@ public class RestrictionVisitor implements OWLObjectVisitor {
 				for (String j: restrictionsValuesFromClass.keySet()) {
 					if (j.equals(property_name)) {
 						Map<String,String> value = restrictionsValuesFromClass.get(property_name);
-						for (String i : value.keySet() ) {
+						for (String i: value.keySet() ) {
 							restrictionsValues.put(restriction, i);
 						}
 
@@ -484,7 +484,7 @@ public class RestrictionVisitor implements OWLObjectVisitor {
 		Map<String, String> restrictionsValues = new HashMap<String, String>();
 		//if the expression ce is not part of a composed expression (existential or universal)
 		if (property_name.equals("")) {
-			for (OWLDataProperty property:properties) {
+			for (OWLDataProperty property: properties) {
 				propertiesFromDataRestrictions.add(property);
 				property_name = sfp.getShortForm(property.getIRI());
 				restrictionsValues.put(restriction, "");
@@ -492,7 +492,7 @@ public class RestrictionVisitor implements OWLObjectVisitor {
 			}
 		} else {
 			List<String> rangeList = new ArrayList<String>();
-			for (OWLDataRange range:ranges) {
+			for (OWLDataRange range: ranges) {
 				rangeList.add(sfp.getShortForm(range.asOWLDatatype().getIRI()));
 				if (range.getClass().equals(owlThing)) {
 					logger.info("Ignoring owl: Thing range" + property_name);
@@ -505,7 +505,7 @@ public class RestrictionVisitor implements OWLObjectVisitor {
 				for (String j: restrictionsValuesFromClass.keySet()) {
 					if (j.equals(property_name)) {
 						Map<String,String> value = restrictionsValuesFromClass.get(property_name);
-						for (String i : value.keySet()) {
+						for (String i: value.keySet()) {
 							restrictionsValues.put(restriction, i);
 						}
 
@@ -524,7 +524,7 @@ public class RestrictionVisitor implements OWLObjectVisitor {
 		String property_name = "";
 		List<String> ranges = new ArrayList<>();
 		Map<String, String> restrictionsValues = new HashMap<>();
-		for (OWLDataProperty property:ce.getDataPropertiesInSignature()) {
+		for (OWLDataProperty property: ce.getDataPropertiesInSignature()) {
 			propertiesFromDataRestrictions.add(property);
 			property_name = sfp.getShortForm(property.getIRI());
 

--- a/src/main/java/edu/isi/oba/RestrictionVisitor.java
+++ b/src/main/java/edu/isi/oba/RestrictionVisitor.java
@@ -32,7 +32,7 @@ import org.semanticweb.owlapi.util.SimpleIRIShortFormProvider;
  *   will be used to map the ObjectProperties its the corresponding Schema.
  * - propertiesFromDataRestrictions -> contains all the restricted OWLDataProperties  
  * - propertiesFromDataRestrictions_ranges -> contains the ranges of each data property restriction    
- * - valuesFromDataRestrictions_ranges -> contains the range values of data restrictions. e.g. oneOf values.                                                 
+ * - valuesFromDataRestrictions_ranges -> contains the range values of data restrictions. e.g. oneOf values.
  */
 
 public class RestrictionVisitor implements OWLObjectVisitor {
@@ -56,10 +56,10 @@ public class RestrictionVisitor implements OWLObjectVisitor {
 		processedClasses = new HashSet<OWLClass>();
 		this.cls = visitedClass;
 		this.onto = onto;
-		this.property_name = propertyName;           
-		this.owlThing = owlThing;   
+		this.property_name = propertyName;
+		this.owlThing = owlThing;
 		this.propertiesFromObjectRestrictions_ranges= new HashMap<>();
-		this.propertiesFromObjectRestrictions = new ArrayList<>();		
+		this.propertiesFromObjectRestrictions = new ArrayList<>();
 		this.restrictionsValuesFromClass = new HashMap<>();
 		this.propertiesFromDataRestrictions = new ArrayList<>();
 		this.propertiesFromDataRestrictions_ranges= new HashMap<>();
@@ -74,12 +74,12 @@ public class RestrictionVisitor implements OWLObjectVisitor {
 			this.processedClasses.add(ce);
 			for (OWLSubClassOfAxiom ax: this.onto.getSubClassAxiomsForSubClass(ce)) {
 				ax.getSuperClass().accept(this);
-			}               
+			}
 		}
 	}
 
 	@Override
-	public void visit( OWLEquivalentClassesAxiom ce ) {		 							    	
+	public void visit( OWLEquivalentClassesAxiom ce ) {
 		logger.info("Analyzing restrictions of Class: " + this.cls+ " with axiom: "+ce);
 
 		// If equivalent class axiom AND contains owl:oneOf, then we're looking at an ENUM class.
@@ -109,9 +109,9 @@ public class RestrictionVisitor implements OWLObjectVisitor {
 		Map<String, String> restrictionsValues = new HashMap<>();
 		logger.info("Analyzing restrictions of Class: " + this.cls + " with axiom: " + ce);
 
-		for(OWLObjectProperty property: ce.getObjectPropertiesInSignature()) {
+		for (OWLObjectProperty property: ce.getObjectPropertiesInSignature()) {
 			this.propertiesFromObjectRestrictions.add(property);
-			this.property_name = this.sfp.getShortForm(property.getIRI());        		
+			this.property_name = this.sfp.getShortForm(property.getIRI());
 		}
 
 		OWLClassExpression ceFiller = ce.getFiller();
@@ -145,28 +145,29 @@ public class RestrictionVisitor implements OWLObjectVisitor {
 	public void visit(OWLObjectAllValuesFrom ce) {
 		logger.info("Analyzing restrictions of Class: " + this.cls+ " with axiom: "+ce);
 		Map<String, String> restrictionsValues = new HashMap<>();
-		for(OWLObjectProperty property:ce.getObjectPropertiesInSignature()) {        		   
+		for (OWLObjectProperty property:ce.getObjectPropertiesInSignature()) {
 			propertiesFromObjectRestrictions.add(property);
-			property_name = sfp.getShortForm(property.getIRI()); 		
+			property_name = sfp.getShortForm(property.getIRI());
 		}
+
 		if (ce.getFiller() instanceof OWLObjectUnionOf || ce.getFiller() instanceof OWLObjectIntersectionOf) {
 			ce.getFiller().accept(this);
-		} else {       	   
+		} else {
 			List<String> ranges = new ArrayList<>();
 			ranges.add(sfp.getShortForm(ce.getFiller().asOWLClass().getIRI()));
 			if (ce.getFiller().asOWLClass().equals(owlThing)) {
-				logger.info("Ignoring owl:Thing range" + property_name);                       
+				logger.info("Ignoring owl:Thing range" + property_name);
 			} else {
 				propertiesFromObjectRestrictions_ranges.put(property_name, ranges);
 			}
 
-			restrictionsValues.put("allValuesFrom", "");			
+			restrictionsValues.put("allValuesFrom", "");
 			restrictionsValuesFromClass.put(property_name, restrictionsValues);
 		}
 	}
 		
 	@Override
-	public void visit( OWLObjectUnionOf ce ) {		 							    	
+	public void visit(OWLObjectUnionOf ce) {
 		logger.info("Analyzing restrictions of Class: " + this.cls+ " with axiom: "+ce);
 		
 		// Loop through each item in the union and accept visits.
@@ -174,8 +175,9 @@ public class RestrictionVisitor implements OWLObjectVisitor {
 			e.accept(this);
 		}
 	}
+
 	@Override
-	public void visit( OWLObjectIntersectionOf ce ) {		 							    	
+	public void visit(OWLObjectIntersectionOf ce) {
 		logger.info("Analyzing restrictions of Class: " + this.cls+ " with axiom: "+ce);
 		
 		// Loop through each item in the intersection and accept visits.
@@ -185,28 +187,29 @@ public class RestrictionVisitor implements OWLObjectVisitor {
 	}
 
 	@Override
-	public void visit( OWLObjectMinCardinality ce ) {
+	public void visit(OWLObjectMinCardinality ce) {
 		logger.info("Analyzing restrictions of Class: " + this.cls+ " with axiom: "+ce);
 		setPropertiesWithCardinality(ce, "minCardinality");
-		
 	}
+
 	@Override
-	public void visit( OWLObjectMaxCardinality ce ) {
-		logger.info("Analyzing restrictions of Class: " + this.cls+ " with axiom: "+ce);	 
-		setPropertiesWithCardinality(ce,"maxCardinality")	;
-	} 
-	@Override
-	public void visit( OWLObjectExactCardinality ce ) {
+	public void visit(OWLObjectMaxCardinality ce) {
 		logger.info("Analyzing restrictions of Class: " + this.cls+ " with axiom: "+ce);
-		setPropertiesWithCardinality(ce,  "exactCardinality")	;
+		setPropertiesWithCardinality(ce,"maxCardinality");
+	}
+
+	@Override
+	public void visit(OWLObjectExactCardinality ce) {
+		logger.info("Analyzing restrictions of Class: " + this.cls+ " with axiom: "+ce);
+		setPropertiesWithCardinality(ce, "exactCardinality");
 	}
 	
 	@Override
-	public void visit( OWLObjectComplementOf ce ) {
+	public void visit(OWLObjectComplementOf ce) {
 		logger.info("Analyzing restrictions of Class: " + this.cls+ " with axiom: "+ce);
 		Map<String, String> restrictionsValues = new HashMap<String, String>();
-		String complementName = this.sfp.getShortForm(ce.getOperand().asOWLClass().getIRI());					
-		restrictionsValues.put("complementOf", complementName );	
+		String complementName = this.sfp.getShortForm(ce.getOperand().asOWLClass().getIRI());
+		restrictionsValues.put("complementOf", complementName );
 		restrictionsValuesFromClass.put("complementOf", restrictionsValues);
  	}
 	
@@ -214,7 +217,7 @@ public class RestrictionVisitor implements OWLObjectVisitor {
 	public void visit(OWLObjectHasValue ce) {
 		logger.info("Analyzing restrictions of Class: " + this.cls + " with axiom: " + ce);
 		
-		for(OWLObjectProperty property: ce.getObjectPropertiesInSignature()) {
+		for (OWLObjectProperty property: ce.getObjectPropertiesInSignature()) {
 			List<String> ranges = new ArrayList<String>();
 			Map<String, String> restrictionsValues = new HashMap<String, String>();
 
@@ -242,7 +245,7 @@ public class RestrictionVisitor implements OWLObjectVisitor {
 	}
 	
 	@Override
-	public void visit( OWLObjectOneOf ce ) {	
+	public void visit(OWLObjectOneOf ce) {
 		logger.info("Analyzing restrictions of Class: " + this.cls + " with axiom: " + ce);
 		List<String> ranges = new ArrayList<String>();
 		Map<String, String> restrictionsValues = new HashMap<String, String>();
@@ -263,26 +266,27 @@ public class RestrictionVisitor implements OWLObjectVisitor {
 	 * (allValuesFrom) restriction and it asks us to visit it
 	 */
 	@Override
-	public void visit( OWLDataAllValuesFrom ce ) {		
+	public void visit(OWLDataAllValuesFrom ce) {
 		logger.info( "\n Analyzed Class: " + this.cls+ " with axiom: "+ce);
 		Map<String, String> restrictionsValues = new HashMap<String, String>();
-		for(OWLDataProperty property:ce.getDataPropertiesInSignature()) {        		   
+		for (OWLDataProperty property:ce.getDataPropertiesInSignature()) {
 			propertiesFromDataRestrictions.add(property);
-			property_name = sfp.getShortForm(property.getIRI());        		
+			property_name = sfp.getShortForm(property.getIRI());
 		}
+
 		if (ce.getFiller() instanceof OWLDataUnionOf || ce.getFiller() instanceof OWLDataIntersectionOf) {
 			ce.getFiller().accept(this);
-		} else {       	   
+		} else {
 			List<String> ranges = new ArrayList<String>();
 			ranges.add(sfp.getShortForm(ce.getFiller().asOWLDatatype().getIRI()));
 			if (ce.getFiller().asOWLDatatype().equals(owlThing)) {
-				logger.info("Ignoring owl:Thing range" + property_name);                       
+				logger.info("Ignoring owl:Thing range" + property_name);
+			} else {
+				propertiesFromDataRestrictions_ranges.put(property_name,ranges);
 			}
-			else
-				propertiesFromDataRestrictions_ranges.put(property_name,ranges);        		  
 
-			restrictionsValues.put("allValuesFrom", "");			
-			restrictionsValuesFromClass.put(property_name, restrictionsValues);		
+			restrictionsValues.put("allValuesFrom", "");
+			restrictionsValuesFromClass.put(property_name, restrictionsValues);
 		}
 	}
 	
@@ -291,28 +295,28 @@ public class RestrictionVisitor implements OWLObjectVisitor {
 	 * (someValuesFrom) restriction and it asks us to visit it
 	 */
 	@Override
-	public void visit( OWLDataSomeValuesFrom ce ) {
+	public void visit(OWLDataSomeValuesFrom ce) {
 		logger.info( "\n Analyzed Class: " + this.cls + " with axiom: " + ce);
 		Map<String, String> restrictionsValues = new HashMap<String, String>();
-		for(OWLDataProperty property: ce.getDataPropertiesInSignature()) {        		   
+		for (OWLDataProperty property: ce.getDataPropertiesInSignature()) {
 			this.propertiesFromDataRestrictions.add(property);
 			this.property_name = this.sfp.getShortForm(property.getIRI());
 		}
 
 		OWLDataRange ceFiller = ce.getFiller();
 		if (ceFiller instanceof OWLDataUnionOf || ceFiller instanceof OWLDataIntersectionOf) {
-			restrictionsValues.put("someValuesFrom", "");			
+			restrictionsValues.put("someValuesFrom", "");
 			this.restrictionsValuesFromClass.put(property_name, restrictionsValues);
 			ce.getFiller().accept(this);
-		} else {       	   
+		} else {
 			List<String> ranges = new ArrayList<String>();
 			ranges.add(this.sfp.getShortForm(ceFiller.asOWLDatatype().getIRI()));
 
 			if (ceFiller.asOWLDatatype().equals(owlThing)) {
-				logger.info("Ignoring owl:Thing range" + property_name);                       
+				logger.info("Ignoring owl:Thing range" + property_name);
 			} else {
-				propertiesFromDataRestrictions_ranges.put(property_name, ranges);  
-			}      		  
+				propertiesFromDataRestrictions_ranges.put(property_name, ranges);
+			}
 
 			restrictionsValues.put("someValuesFrom", "");
 			this.restrictionsValuesFromClass.put(property_name, restrictionsValues);
@@ -320,7 +324,7 @@ public class RestrictionVisitor implements OWLObjectVisitor {
 	}
 
 	@Override
-	public void visit( OWLDataUnionOf ce ) {
+	public void visit(OWLDataUnionOf ce) {
 		logger.info("Analyzing restrictions of Class: " + this.cls+ " with axiom: "+ce);
 		
 		// Loop through each item in the union and accept visits.
@@ -330,7 +334,7 @@ public class RestrictionVisitor implements OWLObjectVisitor {
 	}
 	
 	@Override
-	public void visit( OWLDataIntersectionOf ce ) {
+	public void visit(OWLDataIntersectionOf ce) {
 		logger.info("Analyzing restrictions of Class: " + this.cls+ " with axiom: "+ce);
 
 		// Loop through each item in the intersection and accept visits.
@@ -340,26 +344,26 @@ public class RestrictionVisitor implements OWLObjectVisitor {
 	}
 	
 	@Override
-	public void visit( OWLDataMinCardinality ce ) {
-		logger.info("Analyzing restrictions of Class: " + this.cls+ " with axiom: "+ce);		
+	public void visit(OWLDataMinCardinality ce) {
+		logger.info("Analyzing restrictions of Class: " + this.cls+ " with axiom: "+ce);
 		setDataPropertiesWithCardinality(ce,"minCardinality");
 	}
 	
 	@Override
-	public void visit( OWLDataMaxCardinality ce ) {
-		logger.info("Analyzing restrictions of Class: " + this.cls+ " with axiom: "+ce);	
+	public void visit(OWLDataMaxCardinality ce) {
+		logger.info("Analyzing restrictions of Class: " + this.cls+ " with axiom: "+ce);
 		setDataPropertiesWithCardinality(ce,"maxCardinality");
-	} 
+	}
 	
 	@Override
-	public void visit( OWLDataExactCardinality ce ) {
-		logger.info("Analyzing restrictions of Class: " + this.cls+ " with axiom: "+ce);		
+	public void visit(OWLDataExactCardinality ce) {
+		logger.info("Analyzing restrictions of Class: " + this.cls+ " with axiom: "+ce);
 		setDataPropertiesWithCardinality(ce,"exactCardinality");
 	}
 	
 	@Override
-	public void visit( OWLDataOneOf ce ) {	
-		logger.info("Analyzing restrictions of Class: " + this.cls + " with axiom: " + ce);	
+	public void visit(OWLDataOneOf ce) {
+		logger.info("Analyzing restrictions of Class: " + this.cls + " with axiom: " + ce);
 		List<String> ranges = new ArrayList<String>();
 		Map<String, String> restrictionsValues = new HashMap<String, String>();
 
@@ -373,10 +377,10 @@ public class RestrictionVisitor implements OWLObjectVisitor {
 	}
 
 	@Override
-	public void visit( OWLDataComplementOf ce ) {
+	public void visit(OWLDataComplementOf ce) {
 		logger.info("Analyzing restrictions of Class: " + this.cls + " with axiom: " + ce);
 		List<String> ranges = new ArrayList<String>();
-		Map<String, String> restrictionsValues = new HashMap<String, String>();					
+		Map<String, String> restrictionsValues = new HashMap<String, String>();
 		for (OWLDatatype value: ce.getDatatypesInSignature()) {
 			ranges.add(this.sfp.getShortForm(value.getIRI()));
 			restrictionsValues.put("complementOf", "");
@@ -386,11 +390,11 @@ public class RestrictionVisitor implements OWLObjectVisitor {
 	}
 	
 	@Override
-	public void visit( OWLDataHasValue ce ) {
+	public void visit(OWLDataHasValue ce) {
 		logger.info("Analyzing restrictions of Class: " + this.cls + " with axiom: " + ce);
 		List<String> ranges = new ArrayList<String>();
 		Map<String, String> restrictionsValues = new HashMap<String, String>();
-		for(OWLDataProperty property: ce.getDataPropertiesInSignature()) {
+		for (OWLDataProperty property: ce.getDataPropertiesInSignature()) {
 			property_name = this.sfp.getShortForm(property.getIRI());
 			propertiesFromDataRestrictions.add(property);
 			restrictionsValues.put("dataHasValue", ce.getFiller().getLiteral());
@@ -409,18 +413,19 @@ public class RestrictionVisitor implements OWLObjectVisitor {
      * @param restriction string value of restriction e.g. "exactCardinality"
      */
 	public void setPropertiesWithCardinality(OWLObjectCardinalityRestriction ce, String restriction) {
-		String property_name="";
+		String property_name = "";
 		List<String> ranges = new ArrayList<String>();
 		Map<String, String> restrictionsValues = new HashMap<String, String>();
-		for(OWLObjectProperty property:ce.getObjectPropertiesInSignature()) {
+		for (OWLObjectProperty property:ce.getObjectPropertiesInSignature()) {
 			propertiesFromObjectRestrictions.add(property);
-			property_name = sfp.getShortForm(property.getIRI());    	
+			property_name = sfp.getShortForm(property.getIRI());
 			ranges.add(sfp.getShortForm(ce.getFiller().asOWLClass().getIRI()));
 			propertiesFromObjectRestrictions_ranges.put(property_name,ranges);
-		}	    
-		this.property_name =  property_name;
+		}
+
+		this.property_name = property_name;
 		
-		restrictionsValues.put(restriction, Integer.toString(ce.getCardinality()));			
+		restrictionsValues.put(restriction, Integer.toString(ce.getCardinality()));
 		restrictionsValuesFromClass.put(property_name, restrictionsValues);
 	}
 	
@@ -432,41 +437,41 @@ public class RestrictionVisitor implements OWLObjectVisitor {
      */
 	public void setBooleanCombinationProperties( Set<OWLClassExpression> ranges, Set<OWLObjectProperty> properties, String restriction) {
 		Map<String, String> restrictionsValues = new HashMap<String, String>();
-			//if the expression ce is not part of a composed expression (existential or universal)
-			if (property_name.isEmpty()) {
-				for(OWLObjectProperty property:properties) {
-					propertiesFromObjectRestrictions.add(property);
-					property_name = sfp.getShortForm(property.getIRI());
-					restrictionsValues.put(restriction, "");			
-					restrictionsValuesFromClass.put(property_name, restrictionsValues);
-				}
-			} else { 
-				List<String> rangeList = new ArrayList<String>();
-				for (OWLClassExpression range:ranges) {  
-					rangeList.add(sfp.getShortForm(range.asOWLClass().getIRI()));
-					if (range.asOWLClass().equals(owlThing)) {
-						logger.info("Ignoring owl:Thing range" + property_name);                       
-					}
-					else {						
-						propertiesFromObjectRestrictions_ranges.put(property_name,rangeList);							
-					} 					
-				}
-				
-				if (!restrictionsValuesFromClass.isEmpty()) {
-					for (String j :  restrictionsValuesFromClass.keySet()) { 
-						if (j.equals(property_name)) {
-							Map<String,String> value = restrictionsValuesFromClass.get(property_name);
-							for (String i : value.keySet() ) {
-								restrictionsValues.put(restriction, i);
-							}
-							restrictionsValuesFromClass.put(property_name, restrictionsValues);
-						}
-					}
+		//if the expression ce is not part of a composed expression (existential or universal)
+		if (property_name.isEmpty()) {
+			for (OWLObjectProperty property:properties) {
+				propertiesFromObjectRestrictions.add(property);
+				property_name = sfp.getShortForm(property.getIRI());
+				restrictionsValues.put(restriction, "");
+				restrictionsValuesFromClass.put(property_name, restrictionsValues);
+			}
+		} else {
+			List<String> rangeList = new ArrayList<String>();
+			for (OWLClassExpression range:ranges) {
+				rangeList.add(sfp.getShortForm(range.asOWLClass().getIRI()));
+				if (range.asOWLClass().equals(owlThing)) {
+					logger.info("Ignoring owl:Thing range" + property_name);
 				} else {
-					restrictionsValues.put(restriction, "");			
-					restrictionsValuesFromClass.put(property_name, restrictionsValues);
+					propertiesFromObjectRestrictions_ranges.put(property_name,rangeList);
 				}
 			}
+			
+			if (!restrictionsValuesFromClass.isEmpty()) {
+				for (String j: restrictionsValuesFromClass.keySet()) {
+					if (j.equals(property_name)) {
+						Map<String,String> value = restrictionsValuesFromClass.get(property_name);
+						for (String i : value.keySet() ) {
+							restrictionsValues.put(restriction, i);
+						}
+
+						restrictionsValuesFromClass.put(property_name, restrictionsValues);
+					}
+				}
+			} else {
+				restrictionsValues.put(restriction, "");
+				restrictionsValuesFromClass.put(property_name, restrictionsValues);
+			}
+		}
 	}
 	
 	 /**
@@ -475,60 +480,62 @@ public class RestrictionVisitor implements OWLObjectVisitor {
      * @param properties data properties expression that have the boolean restriction 
      * @param restriction string value of restriction e.g. "unionOf"
      */
-	public void setBooleanCombinationDataProperties( Set<OWLDataRange> ranges, Set<OWLDataProperty> properties, String restriction) {
+	public void setBooleanCombinationDataProperties(Set<OWLDataRange> ranges, Set<OWLDataProperty> properties, String restriction) {
 		Map<String, String> restrictionsValues = new HashMap<String, String>();
-			//if the expression ce is not part of a composed expression (existential or universal)
-			if (property_name.equals("")) {
-				for(OWLDataProperty property:properties) {
-					propertiesFromDataRestrictions.add(property);
-					property_name = sfp.getShortForm(property.getIRI());
-					restrictionsValues.put(restriction, "");			
-					restrictionsValuesFromClass.put(property_name, restrictionsValues);
-				}
-			} else { 
-				List<String> rangeList = new ArrayList<String>();
-				for (OWLDataRange range:ranges) {  
-					rangeList.add(sfp.getShortForm(range.asOWLDatatype().getIRI()));
-					if (range.getClass().equals(owlThing)) {
-						logger.info("Ignoring owl: Thing range" + property_name);
-					}
-					else {						
-						propertiesFromDataRestrictions_ranges.put(property_name,rangeList);							
-					} 					
-				}				
-				if (!restrictionsValuesFromClass.isEmpty()) {
-					for (String j :  restrictionsValuesFromClass.keySet()) { 
-						if (j.equals(property_name)) {
-							Map<String,String> value = restrictionsValuesFromClass.get(property_name);
-							for (String i : value.keySet()) {
-								restrictionsValues.put(restriction, i);
-							}
-							restrictionsValuesFromClass.put(property_name, restrictionsValues);
-						break;
-						}
-					}
-				}
-				else {
-					restrictionsValues.put(restriction, "");			
-					restrictionsValuesFromClass.put(property_name, restrictionsValues);
+		//if the expression ce is not part of a composed expression (existential or universal)
+		if (property_name.equals("")) {
+			for (OWLDataProperty property:properties) {
+				propertiesFromDataRestrictions.add(property);
+				property_name = sfp.getShortForm(property.getIRI());
+				restrictionsValues.put(restriction, "");
+				restrictionsValuesFromClass.put(property_name, restrictionsValues);
+			}
+		} else {
+			List<String> rangeList = new ArrayList<String>();
+			for (OWLDataRange range:ranges) {
+				rangeList.add(sfp.getShortForm(range.asOWLDatatype().getIRI()));
+				if (range.getClass().equals(owlThing)) {
+					logger.info("Ignoring owl: Thing range" + property_name);
+				} else {
+					propertiesFromDataRestrictions_ranges.put(property_name,rangeList);
 				}
 			}
+
+			if (!restrictionsValuesFromClass.isEmpty()) {
+				for (String j: restrictionsValuesFromClass.keySet()) {
+					if (j.equals(property_name)) {
+						Map<String,String> value = restrictionsValuesFromClass.get(property_name);
+						for (String i : value.keySet()) {
+							restrictionsValues.put(restriction, i);
+						}
+
+						restrictionsValuesFromClass.put(property_name, restrictionsValues);
+						break;
+					}
+				}
+			} else {
+				restrictionsValues.put(restriction, "");
+				restrictionsValuesFromClass.put(property_name, restrictionsValues);
+			}
+		}
 	}
 
 	public void setDataPropertiesWithCardinality(OWLDataCardinalityRestriction ce, String restriction) {
-		String property_name="";
+		String property_name = "";
 		List<String> ranges = new ArrayList<>();
 		Map<String, String> restrictionsValues = new HashMap<>();
-		for(OWLDataProperty property:ce.getDataPropertiesInSignature()) {
+		for (OWLDataProperty property:ce.getDataPropertiesInSignature()) {
 			propertiesFromDataRestrictions.add(property);
-			property_name = sfp.getShortForm(property.getIRI());    				
-			for (OWLDatatype value:ce.getDatatypesInSignature()){
+			property_name = sfp.getShortForm(property.getIRI());
+
+			for (OWLDatatype value: ce.getDatatypesInSignature()) {
 				ranges.add(sfp.getShortForm(value.getIRI()));
 				propertiesFromDataRestrictions_ranges.put(property_name,ranges);
 			}
-		}	    
+		}
+
 		this.property_name = property_name;
-		restrictionsValues.put(restriction, Integer.toString(ce.getCardinality()));			
+		restrictionsValues.put(restriction, Integer.toString(ce.getCardinality()));
 		restrictionsValuesFromClass.put(property_name, restrictionsValues);
 	}
 	
@@ -562,5 +569,5 @@ public class RestrictionVisitor implements OWLObjectVisitor {
 
 	public Map<IRI, List<String>> getAllEnums() {
 		return this.enums;
-    }
+	}
 }

--- a/src/main/java/edu/isi/oba/RestrictionVisitor.java
+++ b/src/main/java/edu/isi/oba/RestrictionVisitor.java
@@ -2,14 +2,15 @@ package edu.isi.oba;
 
 import static edu.isi.oba.Oba.logger;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import javax.annotation.Nonnull;
+
 import org.semanticweb.owlapi.model.*;
+import org.semanticweb.owlapi.reasoner.structural.StructuralReasonerFactory;
 import org.semanticweb.owlapi.util.IRIShortFormProvider;
 import org.semanticweb.owlapi.util.SimpleIRIShortFormProvider;
 
@@ -37,60 +38,145 @@ import org.semanticweb.owlapi.util.SimpleIRIShortFormProvider;
 
 public class RestrictionVisitor implements OWLObjectVisitor {
 	private final IRIShortFormProvider sfp = new SimpleIRIShortFormProvider();
-	private final Set<OWLClass> processedClasses;
+	private final Set<OWLClass> processedClasses = new HashSet<OWLClass>();
 	private final OWLClass cls;
-	private final OWLOntology onto;
+	private final Set<OWLOntology> ontologies;
 	String property_name;
-	OWLClass owlThing;
+	private OWLClass owlThing;
 	
-	public Map<String, Map<String,String>> restrictionsValuesFromClass;
+	private Map<String, Map<String,String>> restrictionsValuesFromClass = new HashMap<>();
 	
-	public List<OWLObjectProperty> propertiesFromObjectRestrictions;
-	public Map<String, List<String>> propertiesFromObjectRestrictions_ranges;
-	public List<OWLDataProperty> propertiesFromDataRestrictions;
-	public Map<String, List<String>> propertiesFromDataRestrictions_ranges;
-	public List<String> valuesFromDataRestrictions_ranges;
-	public Map<IRI, List<String>> enums;
+	private Set<OWLObjectProperty> propertiesFromObjectRestrictions = new HashSet<>();
+	private Map<String, Set<String>> propertiesFromObjectRestrictions_ranges = new HashMap<>();
+	private Set<OWLDataProperty> propertiesFromDataRestrictions = new HashSet<>();
+	private Map<String, Set<String>> propertiesFromDataRestrictions_ranges = new HashMap<>();
+	private Set<String> valuesFromDataRestrictions_ranges = new HashSet<>();
+	private Map<IRI, Set<String>> enums = new HashMap<>();
 
-	RestrictionVisitor(OWLClass visitedClass, OWLOntology onto, OWLClass owlThing, String propertyName ) {
-		processedClasses = new HashSet<OWLClass>();
+	/**
+	 * Constructor for restriction visitor.
+	 * 
+	 * @param visitedClass the class being checked for restrictions
+	 * @param ontologies the set of loaded ontologies (presumably the visited class is within one of these)
+	 * @param propertyName
+	 */
+	RestrictionVisitor(OWLClass visitedClass, Set<OWLOntology> ontologies, String propertyName) {
 		this.cls = visitedClass;
-		this.onto = onto;
+		this.ontologies = ontologies;
 		this.property_name = propertyName;
-		this.owlThing = owlThing;
-		this.propertiesFromObjectRestrictions_ranges= new HashMap<>();
-		this.propertiesFromObjectRestrictions = new ArrayList<>();
-		this.restrictionsValuesFromClass = new HashMap<>();
-		this.propertiesFromDataRestrictions = new ArrayList<>();
-		this.propertiesFromDataRestrictions_ranges= new HashMap<>();
-		this.valuesFromDataRestrictions_ranges = new ArrayList<>();
-		this.enums = new HashMap<>();
+
+		this.ontologies.forEach((ontology) -> {
+			if (ontology.containsClassInSignature(this.cls.getIRI())) {
+				this.owlThing = new StructuralReasonerFactory().createReasoner(ontology).getTopClassNode().getRepresentativeElement();
+			}
+		});
 	}
 
-	@Override
-	public void visit(OWLClass ce) {
-		if (!this.processedClasses.contains(ce)) {
-			// If we are processing inherited restrictions then we recursively visit named supers. 
-			this.processedClasses.add(ce);
-			for (OWLSubClassOfAxiom ax: this.onto.getSubClassAxiomsForSubClass(ce)) {
-				ax.getSuperClass().accept(this);
-			}
+	/**
+	 * Convenience method for adding/updating restrictions to a property (i.e. in the {@link restrictionsValuesFromClass} map).
+	 * 
+	 * @param propertyName the property name to attach the restriction to
+	 * @param restrictionKey the restriction's name/key
+	 * @param restrictionValue the restriction's value
+	 */
+	private void addRestrictionValueToProperty(String propertyName, String restrictionKey, String restrictionValue) {
+		Map<String, String> restrictions = new HashMap<>();
+
+		if (!this.restrictionsValuesFromClass.containsKey(propertyName)) {
+			logger.info("No restriction values for " + propertyName + " exist yet.  Creating now.");
+		} else {
+			restrictions = this.restrictionsValuesFromClass.get(propertyName);
+		}
+
+		if (restrictions.containsKey(restrictionKey)) {
+			// What should happen here?  There is a chance they differ?
+			logger.warning("Restriction value (= \"" + restrictionValue + "\") for " + propertyName + " already exists.  Ignoring...");
+		} else {
+			logger.info("Adding restriction <\"" + restrictionKey + "\", \"" + restrictionValue + "\"> to property \"" + propertyName + "\".\n");
+			restrictions.put(restrictionKey, restrictionValue);
+			this.restrictionsValuesFromClass.put(propertyName, restrictions);
+		}
+	}
+
+	/**
+	 * Convenience method for adding/updating object restriction ranges to a property (i.e. in the {@link propertiesFromObjectRestrictions_ranges} map).
+	 * 
+	 * @param propertyName the property name to attach the restriction range to
+	 * @param range the object restriction range
+	 */
+	private void addObjectRestrictionRangeToProperty(String propertyName, String range) {
+		Set<String> restrictionRanges = new HashSet<>();
+
+		if (!this.propertiesFromObjectRestrictions_ranges.containsKey(propertyName)) {
+			logger.info("No object restriction ranges for " + propertyName + " exist yet.  Creating now.");
+		} else {
+			restrictionRanges = this.propertiesFromObjectRestrictions_ranges.get(propertyName);
+		}
+
+		if (restrictionRanges.contains(range)) {
+			// What should happen here?  There is a chance they differ?
+			logger.warning("Restriction range (= \"" + range + "\") for " + propertyName + " already exists.  Ignoring...");
+		} else {
+			logger.info("Adding object restriction range \"" + range + "\" to property \"" + propertyName + "\".\n");
+			restrictionRanges.add(range);
+			this.propertiesFromObjectRestrictions_ranges.put(propertyName, restrictionRanges);
+		}
+	}
+
+	/**
+	 * Convenience method for adding/updating data restriction ranges to a property (i.e. in the {@link propertiesFromDataRestrictions_ranges} map).
+	 * 
+	 * @param propertyName the property name to attach the restriction range to
+	 * @param range the data restriction range
+	 */
+	private void addDataRestrictionRangeToProperty(String propertyName, String range) {
+		Set<String> restrictionRanges = new HashSet<>();
+
+		if (!this.propertiesFromDataRestrictions_ranges.containsKey(propertyName)) {
+			logger.info("No data restriction ranges for " + propertyName + " exist yet.  Creating now.");
+		} else {
+			restrictionRanges = this.propertiesFromDataRestrictions_ranges.get(propertyName);
+		}
+
+		if (restrictionRanges.contains(range)) {
+			// What should happen here?  There is a chance they differ?
+			logger.warning("Restriction range (= \"" + range + "\") for " + propertyName + " already exists.  Ignoring...");
+		} else {
+			logger.info("Adding object restriction range \"" + range + "\" to property \"" + propertyName + "\".\n");
+			restrictionRanges.add(range);
+			this.propertiesFromDataRestrictions_ranges.put(propertyName, restrictionRanges);
 		}
 	}
 
 	@Override
-	public void visit( OWLEquivalentClassesAxiom ce ) {
+        public void visit(@Nonnull OWLClass ce) {
+            // avoid cycles
+            if (!this.processedClasses.contains(ce)) {
+                // If we are processing inherited restrictions then we recursively visit named supers.
+                this.processedClasses.add(ce);
+
+                for (OWLOntology ont: this.ontologies) {
+                    ont.subClassAxiomsForSubClass(ce)
+                        .forEach(ax -> ax.getSuperClass().accept(this));
+                }
+            }
+        }
+
+	@Override
+	public void visit(@Nonnull OWLEquivalentClassesAxiom ce) {
 		logger.info("Analyzing restrictions of Class: " + this.cls + " with axiom: " + ce);
 
 		// If equivalent class axiom AND contains owl:oneOf, then we're looking at an ENUM class.
 		ce.classExpressions().filter((e) -> e instanceof OWLObjectOneOf).forEach((oneOfObj) -> {
-			var enumValues = new ArrayList<String>();
-			((OWLObjectOneOf) oneOfObj).getOperandsAsList().forEach((indv) -> {
-				enumValues.add(this.sfp.getShortForm(((OWLNamedIndividual) indv).getIRI()));
-			});
+			var enumValues = ((OWLObjectOneOf) oneOfObj).getOperandsAsList();
+			if (enumValues != null && !enumValues.isEmpty()) {
+				// Add enum individuals to restriction range
+				enumValues.forEach((indv) -> {
+					this.addObjectRestrictionRangeToProperty(this.property_name, this.sfp.getShortForm(((OWLNamedIndividual) indv).getIRI()));
+				});
 
-			if (!enumValues.isEmpty()) {
-				this.enums.put(this.cls.getIRI(), enumValues);
+				// For class enums, this is a misnomer.  There are no properties, in this case, and the property name will be an empty string.  Thi
+				this.addRestrictionValueToProperty(this.property_name, "enum", "");
 			}
 		});
 
@@ -101,40 +187,87 @@ public class RestrictionVisitor implements OWLObjectVisitor {
 	}
 
 	/**
+	 * Convenience method for adding restriction values and ranges from a visit to {@link OWLNaryBooleanClassExpression} (i.e. {@link OWLObjectUnionOf} or {@link OWLObjectIntersectionOf}).
+	 * 
+	 * @param ce the OWLNaryBooleanClassExpression object
+	 */
+	private void visitOWLNaryBooleanClassExpression(@Nonnull OWLNaryBooleanClassExpression ce) {
+		logger.info("Analyzing restrictions of Class: " + this.cls + " with axiom: " + ce);
+
+		String restrictionKey = (ce instanceof OWLObjectUnionOf) ? "unionOf" : "intersectionOf";
+
+		this.addRestrictionValueToProperty(this.property_name, restrictionKey, "");
+		
+		// Loop through each item in the union/intersection and accept visits.
+		for (OWLClassExpression e: ce.getOperands()) {
+			if (e.isOWLClass()) {
+				this.addObjectRestrictionRangeToProperty(this.property_name, this.sfp.getShortForm(e.asOWLClass().getIRI()));
+			} else {
+				e.accept(this);
+			}
+		}
+	}
+		
+	@Override
+	public void visit(@Nonnull OWLObjectUnionOf ce) {
+		this.visitOWLNaryBooleanClassExpression(ce);
+	}
+
+	@Override
+	public void visit(@Nonnull OWLObjectIntersectionOf ce) {
+		this.visitOWLNaryBooleanClassExpression(ce);
+	}
+
+	/**
+	 * Convenience method for adding restriction values and ranges from a visit to {@link OWLQuantifiedObjectRestriction} 
+	 * (i.e. {@link OWLObjectAllValuesFrom}, {@link OWLObjectSomeValuesFrom}, or
+	 * {@link OWLObjectCardinalityRestriction [subinterfaces: {@link OWLObjectExactCardinality}, {@link OWLObjectMaxCardinality}, or {@link OWLObjectMinCardinality}]).
+	 * 
+	 * @param ce the {@link OWLQuantifiedObjectRestriction} object
+	 */
+	private void visitOWLQuantifiedObjectRestriction(@Nonnull OWLQuantifiedObjectRestriction or) {
+		logger.info("Analyzing restrictions of Class: " + this.cls + " with axiom: " + or);
+
+		this.property_name = this.sfp.getShortForm(or.getProperty().asOWLObjectProperty().getIRI());
+
+		String restrictionKey = "";
+
+		if (or instanceof OWLObjectAllValuesFrom) {
+			restrictionKey = "allValuesFrom";
+		} else if (or instanceof OWLObjectSomeValuesFrom) {
+			restrictionKey = "someValuesFrom";
+		} else if (or instanceof OWLObjectMinCardinality) {
+			restrictionKey = "minCardinality";
+		} else if (or instanceof OWLObjectMaxCardinality) {
+			restrictionKey = "maxCardinality";
+		} else if (or instanceof OWLObjectExactCardinality) {
+			restrictionKey = "exactCardinality";
+		}
+
+		// If it is a cardinality type, set the restriction's value, otherwise an empty string.
+		String restrictionValue = (or instanceof OWLObjectCardinalityRestriction) ? Integer.toString(((OWLObjectCardinalityRestriction) or).getCardinality()) : "";
+
+		this.addRestrictionValueToProperty(this.property_name, restrictionKey, restrictionValue);
+
+		final var ce = or.getFiller();
+		if (ce instanceof OWLObjectUnionOf || ce instanceof OWLObjectIntersectionOf || ce instanceof OWLObjectOneOf) {
+			ce.accept(this);
+		} else {
+			if (ce.asOWLClass().equals(this.owlThing)) {
+				logger.info("Ignoring owl:Thing range" + this.property_name);
+			} else {
+				this.addObjectRestrictionRangeToProperty(this.property_name, this.sfp.getShortForm(ce.asOWLClass().getIRI()));
+			}
+		}
+	}
+
+	/**
 	 * This method gets called when a class expression is an existential
 	 * (someValuesFrom) restriction and it asks us to visit it
 	 */
 	@Override
-	public void visit(OWLObjectSomeValuesFrom ce) {
-		Map<String, String> restrictionsValues = new HashMap<>();
-		logger.info("Analyzing restrictions of Class: " + this.cls + " with axiom: " + ce);
-
-		for (OWLObjectProperty property: ce.getObjectPropertiesInSignature()) {
-			this.propertiesFromObjectRestrictions.add(property);
-			this.property_name = this.sfp.getShortForm(property.getIRI());
-		}
-
-		OWLClassExpression ceFiller = ce.getFiller();
-		if (ceFiller instanceof OWLObjectUnionOf || ceFiller instanceof OWLObjectIntersectionOf || ceFiller instanceof OWLObjectOneOf) {
-			restrictionsValues.put("someValuesFrom", "");
-			this.restrictionsValuesFromClass.put(this.property_name, restrictionsValues);
-			ce.getFiller().accept(this);
-		} else {
-			if (ceFiller.asOWLClass().equals(owlThing)) {
-				logger.info("Ignoring owl:Thing range" + this.property_name);
-			} else {
-				if (this.propertiesFromObjectRestrictions_ranges.containsKey(this.property_name)) {
-					this.propertiesFromObjectRestrictions_ranges.get(this.property_name).add(this.sfp.getShortForm(ceFiller.asOWLClass().getIRI()));
-				} else {
-					List<String> ranges = new ArrayList<>();
-					ranges.add(this.sfp.getShortForm(ceFiller.asOWLClass().getIRI()));
-					this.propertiesFromObjectRestrictions_ranges.put(this.property_name, ranges);
-				}
-			}
-			
-			restrictionsValues.put("someValuesFrom", "");
-			this.restrictionsValuesFromClass.put(this.property_name, restrictionsValues);
-		}
+	public void visit(@Nonnull OWLObjectSomeValuesFrom ce) {
+		this.visitOWLQuantifiedObjectRestriction(ce);
 	}
 	
 	/**
@@ -142,152 +275,152 @@ public class RestrictionVisitor implements OWLObjectVisitor {
 	 * (allValuesFrom) restriction and it asks us to visit it
 	 */
 	@Override
-	public void visit(OWLObjectAllValuesFrom ce) {
+	public void visit(@Nonnull OWLObjectAllValuesFrom ce) {
+		this.visitOWLQuantifiedObjectRestriction(ce);
+	}
+
+	@Override
+	public void visit(@Nonnull OWLObjectMinCardinality ce) {
+		this.visitOWLQuantifiedObjectRestriction(ce);
+	}
+
+	@Override
+	public void visit(@Nonnull OWLObjectMaxCardinality ce) {
+		this.visitOWLQuantifiedObjectRestriction(ce);
+	}
+
+	@Override
+	public void visit(@Nonnull OWLObjectExactCardinality ce) {
+		this.visitOWLQuantifiedObjectRestriction(ce);
+	}
+	
+	@Override
+	public void visit(@Nonnull OWLObjectComplementOf ce) {
 		logger.info("Analyzing restrictions of Class: " + this.cls + " with axiom: " + ce);
-		Map<String, String> restrictionsValues = new HashMap<>();
-		for (OWLObjectProperty property: ce.getObjectPropertiesInSignature()) {
-			propertiesFromObjectRestrictions.add(property);
-			property_name = sfp.getShortForm(property.getIRI());
-		}
+
+		String complementName = this.sfp.getShortForm(ce.getOperand().asOWLClass().getIRI());
+		this.addRestrictionValueToProperty("complementOf", "complementOf", complementName);
+ 	}
+	
+	@Override
+	public void visit(@Nonnull OWLObjectHasValue ce) {
+		logger.info("Analyzing restrictions of Class: " + this.cls + " with axiom: " + ce);
+
+		this.property_name = this.sfp.getShortForm(ce.getProperty().asOWLObjectProperty().getIRI());
 
 		if (ce.getFiller() instanceof OWLObjectUnionOf || ce.getFiller() instanceof OWLObjectIntersectionOf) {
 			ce.getFiller().accept(this);
 		} else {
-			List<String> ranges = new ArrayList<>();
-			ranges.add(sfp.getShortForm(ce.getFiller().asOWLClass().getIRI()));
-			if (ce.getFiller().asOWLClass().equals(owlThing)) {
-				logger.info("Ignoring owl:Thing range" + property_name);
-			} else {
-				propertiesFromObjectRestrictions_ranges.put(property_name, ranges);
-			}
+			for (OWLObjectProperty property: ce.getObjectPropertiesInSignature()) {
+				this.ontologies.forEach((ontology) -> {
+					// If object property has object(s) in its range, we want to set references to the object class.
+					var obRangeAxioms = ontology.getObjectPropertyRangeAxioms(property);
+					if (obRangeAxioms.isEmpty()) {
+						logger.warning("\tObject has value (named individual) but there is no associated class/reference for the value.  Ontology may have errors.");
+					} else {
+						obRangeAxioms.forEach((obRangeAxiom) -> {
+							obRangeAxiom.getRange().classesInSignature().forEach((owlClass) -> {
+								this.addRestrictionValueToProperty(this.property_name, "objectHasReference", this.sfp.getShortForm(owlClass.getIRI()));
+							});
+						});
+					}
 
-			restrictionsValues.put("allValuesFrom", "");
-			restrictionsValuesFromClass.put(property_name, restrictionsValues);
-		}
-	}
-		
-	@Override
-	public void visit(OWLObjectUnionOf ce) {
-		logger.info("Analyzing restrictions of Class: " + this.cls + " with axiom: " + ce);
-		
-		// Loop through each item in the union and accept visits.
-		for (OWLClassExpression e: ce.getOperands()) {
-			e.accept(this);
-		}
-	}
-
-	@Override
-	public void visit(OWLObjectIntersectionOf ce) {
-		logger.info("Analyzing restrictions of Class: " + this.cls + " with axiom: " + ce);
-		
-		// Loop through each item in the intersection and accept visits.
-		for (OWLClassExpression e: ce.getOperands()) {
-			e.accept(this);
-		}
-	}
-
-	@Override
-	public void visit(OWLObjectMinCardinality ce) {
-		logger.info("Analyzing restrictions of Class: " + this.cls + " with axiom: " + ce);
-		setPropertiesWithCardinality(ce, "minCardinality");
-	}
-
-	@Override
-	public void visit(OWLObjectMaxCardinality ce) {
-		logger.info("Analyzing restrictions of Class: " + this.cls + " with axiom: " + ce);
-		setPropertiesWithCardinality(ce,"maxCardinality");
-	}
-
-	@Override
-	public void visit(OWLObjectExactCardinality ce) {
-		logger.info("Analyzing restrictions of Class: " + this.cls + " with axiom: " + ce);
-		setPropertiesWithCardinality(ce, "exactCardinality");
-	}
-	
-	@Override
-	public void visit(OWLObjectComplementOf ce) {
-		logger.info("Analyzing restrictions of Class: " + this.cls + " with axiom: " + ce);
-		Map<String, String> restrictionsValues = new HashMap<String, String>();
-		String complementName = this.sfp.getShortForm(ce.getOperand().asOWLClass().getIRI());
-		restrictionsValues.put("complementOf", complementName );
-		restrictionsValuesFromClass.put("complementOf", restrictionsValues);
- 	}
-	
-	@Override
-	public void visit(OWLObjectHasValue ce) {
-		logger.info("Analyzing restrictions of Class: " + this.cls + " with axiom: " + ce);
-		
-		for (OWLObjectProperty property: ce.getObjectPropertiesInSignature()) {
-			List<String> ranges = new ArrayList<String>();
-			Map<String, String> restrictionsValues = new HashMap<String, String>();
-
-			this.property_name = this.sfp.getShortForm(property.getIRI());
-
-			restrictionsValues.put("objectHasValue", this.sfp.getShortForm(((OWLNamedIndividual)ce.getFiller()).getIRI()));
-
-			// If object property has object(s) in its range, we want to set references to the object class.
-			var obRangeAxioms = this.onto.getObjectPropertyRangeAxioms(property);
-			if (obRangeAxioms.isEmpty()) {
-				logger.warning("\tObject has value (named individual) but there is no associated class/reference for the value.  Ontology may have errors.");
-			} else {
-				obRangeAxioms.forEach((obRangeAxiom) -> {
-					obRangeAxiom.getRange().classesInSignature().forEach((owlClass) -> {
-						restrictionsValues.put("objectHasReference", this.sfp.getShortForm(owlClass.getIRI()));
-					});
+					this.propertiesFromObjectRestrictions.add(property);
+					this.addRestrictionValueToProperty(this.property_name, "objectHasValue", this.sfp.getShortForm(((OWLNamedIndividual) ce.getFiller()).getIRI()));
+					this.addObjectRestrictionRangeToProperty(this.property_name, "defaultValue");
 				});
 			}
-
-			this.restrictionsValuesFromClass.put(this.property_name, restrictionsValues);
-			this.propertiesFromObjectRestrictions.add(property);
-			ranges.add("defaultValue");
-			this.propertiesFromObjectRestrictions_ranges.put(this.property_name, ranges);
 		}
 	}
 	
 	@Override
-	public void visit(OWLObjectOneOf ce) {
+	public void visit(@Nonnull OWLObjectOneOf ce) {
 		logger.info("Analyzing restrictions of Class: " + this.cls + " with axiom: " + ce);
-		List<String> ranges = new ArrayList<String>();
-		Map<String, String> restrictionsValues = new HashMap<String, String>();
 
-		if (!property_name.isEmpty()) {
+		if (!this.property_name.isBlank()) {
 			for (OWLIndividual individual: ce.getIndividuals()) {
-				ranges.add(individual.toString());
+				this.addObjectRestrictionRangeToProperty(this.property_name, this.sfp.getShortForm(individual.asOWLNamedIndividual().getIRI()));
 			}
 
-			restrictionsValues.put("oneOf", "someValuesFrom");
-			this.restrictionsValuesFromClass.put(this.property_name, restrictionsValues);
-			this.propertiesFromObjectRestrictions_ranges.put(this.property_name, ranges);
+			this.addRestrictionValueToProperty(this.property_name, "oneOf", "someValuesFrom");
 		}
 	}
-	
+
+	/**
+	 * Convenience method for adding restriction values and ranges from a visit to {@link OWLNaryDataRange} (i.e. {@link OWLDataUnionOf} or {@link OWLDataIntersectionOf}).
+	 * 
+	 * @param ce the OWLNaryDataRange object
+	 */
+	private void visitOWLNaryDataRange(@Nonnull OWLNaryDataRange ce) {
+		logger.info("Analyzing restrictions of Class: " + this.cls + " with axiom: " + ce);
+
+		String restrictionKey = (ce instanceof OWLDataUnionOf) ? "unionOf" : "intersectionOf";
+
+		this.addRestrictionValueToProperty(this.property_name, restrictionKey, "");
+		
+		// Loop through each item in the union/intersection and accept visits.
+		for (OWLDataRange e: ce.getOperands()) {
+			this.addDataRestrictionRangeToProperty(this.property_name, this.sfp.getShortForm(e.asOWLDatatype().getIRI()));
+			e.accept(this);
+		}
+	}
+
+	@Override
+	public void visit(@Nonnull OWLDataUnionOf ce) {
+		this.visitOWLNaryDataRange(ce);
+	}
+
+	@Override
+	public void visit(@Nonnull OWLDataIntersectionOf ce) {
+		this.visitOWLNaryDataRange(ce);
+	}
+
+	 /**
+	 * Convenience method for adding restriction values and ranges from a visit to {@link OWLQuantifiedDataRestriction} 
+	 * (i.e. {@link OWLDataAllValuesFrom}, {@link OWLDataSomeValuesFrom}, or
+	 * {@link OWLDataCardinalityRestriction} [subinterfaces: {@link OWLDataMinCardinality}, {@link OWLDataMaxCardinality}, or {@link OWLDataExactCardinality}]).
+	 * 
+	 * @param ce the {@link OWLQuantifiedDataRestriction} object
+	 */
+	private void visitOWLQuantifiedDataRestriction(@Nonnull OWLQuantifiedDataRestriction dr) {
+		logger.info("Analyzing restrictions of Class: " + this.cls + " with axiom: " + dr);
+
+		this.property_name = this.sfp.getShortForm(dr.getProperty().asOWLDataProperty().getIRI());
+
+		String restrictionKey = "";
+
+		if (dr instanceof OWLDataAllValuesFrom) {
+			restrictionKey = "allValuesFrom";
+		} else if (dr instanceof OWLDataSomeValuesFrom) {
+			restrictionKey = "someValuesFrom";
+		} else if (dr instanceof OWLDataMinCardinality) {
+			restrictionKey = "minCardinality";
+		} else if (dr instanceof OWLDataMaxCardinality) {
+			restrictionKey = "maxCardinality";
+		} else if (dr instanceof OWLDataExactCardinality) {
+			restrictionKey = "exactCardinality";
+		}
+
+		// If it is a cardinality type, set the restriction's value, otherwise an empty string.
+		final String restrictionValue = (dr instanceof OWLDataCardinalityRestriction) ? Integer.toString(((OWLDataCardinalityRestriction) dr).getCardinality()) : "";
+
+		this.addRestrictionValueToProperty(this.property_name, restrictionKey, restrictionValue);
+
+		final var ce = dr.getFiller();
+		if (ce instanceof OWLDataUnionOf || ce instanceof OWLDataIntersectionOf || ce instanceof OWLDataOneOf) {
+			ce.accept(this);
+		} else {
+			this.addDataRestrictionRangeToProperty(this.property_name, this.sfp.getShortForm(ce.asOWLDatatype().getIRI()));
+		}
+	}
+
 	/**
 	 * This method gets called when a class expression is a universal
 	 * (allValuesFrom) restriction and it asks us to visit it
 	 */
 	@Override
-	public void visit(OWLDataAllValuesFrom ce) {
-		logger.info( "\n Analyzed Class: " + this.cls + " with axiom: " + ce);
-		Map<String, String> restrictionsValues = new HashMap<String, String>();
-		for (OWLDataProperty property: ce.getDataPropertiesInSignature()) {
-			propertiesFromDataRestrictions.add(property);
-			property_name = sfp.getShortForm(property.getIRI());
-		}
-
-		if (ce.getFiller() instanceof OWLDataUnionOf || ce.getFiller() instanceof OWLDataIntersectionOf) {
-			ce.getFiller().accept(this);
-		} else {
-			List<String> ranges = new ArrayList<String>();
-			ranges.add(sfp.getShortForm(ce.getFiller().asOWLDatatype().getIRI()));
-			if (ce.getFiller().asOWLDatatype().equals(owlThing)) {
-				logger.info("Ignoring owl:Thing range" + property_name);
-			} else {
-				propertiesFromDataRestrictions_ranges.put(property_name,ranges);
-			}
-
-			restrictionsValues.put("allValuesFrom", "");
-			restrictionsValuesFromClass.put(property_name, restrictionsValues);
-		}
+	public void visit(@Nonnull OWLDataAllValuesFrom ce) {
+		this.visitOWLQuantifiedDataRestriction(ce);
 	}
 	
 	/**
@@ -295,279 +428,129 @@ public class RestrictionVisitor implements OWLObjectVisitor {
 	 * (someValuesFrom) restriction and it asks us to visit it
 	 */
 	@Override
-	public void visit(OWLDataSomeValuesFrom ce) {
-		logger.info( "\n Analyzed Class: " + this.cls + " with axiom: " + ce);
-		Map<String, String> restrictionsValues = new HashMap<String, String>();
-		for (OWLDataProperty property: ce.getDataPropertiesInSignature()) {
-			this.propertiesFromDataRestrictions.add(property);
-			this.property_name = this.sfp.getShortForm(property.getIRI());
-		}
-
-		OWLDataRange ceFiller = ce.getFiller();
-		if (ceFiller instanceof OWLDataUnionOf || ceFiller instanceof OWLDataIntersectionOf) {
-			restrictionsValues.put("someValuesFrom", "");
-			this.restrictionsValuesFromClass.put(property_name, restrictionsValues);
-			ce.getFiller().accept(this);
-		} else {
-			List<String> ranges = new ArrayList<String>();
-			ranges.add(this.sfp.getShortForm(ceFiller.asOWLDatatype().getIRI()));
-
-			if (ceFiller.asOWLDatatype().equals(owlThing)) {
-				logger.info("Ignoring owl:Thing range" + property_name);
-			} else {
-				propertiesFromDataRestrictions_ranges.put(property_name, ranges);
-			}
-
-			restrictionsValues.put("someValuesFrom", "");
-			this.restrictionsValuesFromClass.put(property_name, restrictionsValues);
-		}
-	}
-
-	@Override
-	public void visit(OWLDataUnionOf ce) {
-		logger.info("Analyzing restrictions of Class: " + this.cls + " with axiom: " + ce);
-		
-		// Loop through each item in the union and accept visits.
-		for (OWLDataRange e: ce.getOperands()) {
-			e.accept(this);
-		}
+	public void visit(@Nonnull OWLDataSomeValuesFrom ce) {
+		this.visitOWLQuantifiedDataRestriction(ce);
 	}
 	
 	@Override
-	public void visit(OWLDataIntersectionOf ce) {
-		logger.info("Analyzing restrictions of Class: " + this.cls + " with axiom: " + ce);
-
-		// Loop through each item in the intersection and accept visits.
-		for (OWLDataRange e: ce.getOperands()) {
-			e.accept(this);
-		}
+	public void visit(@Nonnull OWLDataMinCardinality ce) {
+		this.visitOWLQuantifiedDataRestriction(ce);
 	}
 	
 	@Override
-	public void visit(OWLDataMinCardinality ce) {
-		logger.info("Analyzing restrictions of Class: " + this.cls + " with axiom: " + ce);
-		setDataPropertiesWithCardinality(ce,"minCardinality");
+	public void visit(@Nonnull OWLDataMaxCardinality ce) {
+		this.visitOWLQuantifiedDataRestriction(ce);
 	}
 	
 	@Override
-	public void visit(OWLDataMaxCardinality ce) {
-		logger.info("Analyzing restrictions of Class: " + this.cls + " with axiom: " + ce);
-		setDataPropertiesWithCardinality(ce,"maxCardinality");
+	public void visit(@Nonnull OWLDataExactCardinality ce) {
+		this.visitOWLQuantifiedDataRestriction(ce);
 	}
 	
 	@Override
-	public void visit(OWLDataExactCardinality ce) {
+	public void visit(@Nonnull OWLDataOneOf ce) {
 		logger.info("Analyzing restrictions of Class: " + this.cls + " with axiom: " + ce);
-		setDataPropertiesWithCardinality(ce,"exactCardinality");
-	}
-	
-	@Override
-	public void visit(OWLDataOneOf ce) {
-		logger.info("Analyzing restrictions of Class: " + this.cls + " with axiom: " + ce);
-		List<String> ranges = new ArrayList<String>();
-		Map<String, String> restrictionsValues = new HashMap<String, String>();
 
 		for (OWLLiteral value: ce.getValues()) {
-			ranges.add(this.sfp.getShortForm(value.getDatatype().getIRI()));
 			this.valuesFromDataRestrictions_ranges.add(value.getLiteral());
-			restrictionsValues.put("oneOf", "");
-			this.restrictionsValuesFromClass.put(this.property_name, restrictionsValues);
-			this.propertiesFromDataRestrictions_ranges.put(this.property_name, ranges);
+			this.addRestrictionValueToProperty(this.property_name, "oneOf", "");
+			this.addDataRestrictionRangeToProperty(this.property_name, this.sfp.getShortForm(value.getDatatype().getIRI()));
 		}
 	}
 
 	@Override
-	public void visit(OWLDataComplementOf ce) {
+	public void visit(@Nonnull OWLDataComplementOf ce) {
 		logger.info("Analyzing restrictions of Class: " + this.cls + " with axiom: " + ce);
-		List<String> ranges = new ArrayList<String>();
-		Map<String, String> restrictionsValues = new HashMap<String, String>();
+
 		for (OWLDatatype value: ce.getDatatypesInSignature()) {
-			ranges.add(this.sfp.getShortForm(value.getIRI()));
-			restrictionsValues.put("complementOf", "");
-			restrictionsValuesFromClass.put(this.property_name, restrictionsValues);
-			propertiesFromDataRestrictions_ranges.put(this.property_name, ranges);
+			this.addRestrictionValueToProperty(this.property_name, "complementOf", "");
+			this.addDataRestrictionRangeToProperty(this.property_name, this.sfp.getShortForm(value.getIRI()));
 		}
 	}
 	
 	@Override
-	public void visit(OWLDataHasValue ce) {
+	public void visit(@Nonnull OWLDataHasValue ce) {
 		logger.info("Analyzing restrictions of Class: " + this.cls + " with axiom: " + ce);
-		List<String> ranges = new ArrayList<String>();
-		Map<String, String> restrictionsValues = new HashMap<String, String>();
-		for (OWLDataProperty property: ce.getDataPropertiesInSignature()) {
-			property_name = this.sfp.getShortForm(property.getIRI());
-			propertiesFromDataRestrictions.add(property);
-			restrictionsValues.put("dataHasValue", ce.getFiller().getLiteral());
-			restrictionsValuesFromClass.put(property_name, restrictionsValues);
-			
-			for (OWLDatatype value: ce.getDatatypesInSignature()) {
-				ranges.add(this.sfp.getShortForm(value.getIRI()));
-				propertiesFromDataRestrictions_ranges.put(this.property_name, ranges);
-			}
-		}
-	}
 
-	 /**
-     * Method that given a class expression of any cardinality type will set it and its value.
-     * @param ce object cardinality value e.g. OWLObjectExactCardinality
-     * @param restriction string value of restriction e.g. "exactCardinality"
-     */
-	public void setPropertiesWithCardinality(OWLObjectCardinalityRestriction ce, String restriction) {
-		String property_name = "";
-		List<String> ranges = new ArrayList<String>();
-		Map<String, String> restrictionsValues = new HashMap<String, String>();
-		for (OWLObjectProperty property: ce.getObjectPropertiesInSignature()) {
-			propertiesFromObjectRestrictions.add(property);
-			property_name = sfp.getShortForm(property.getIRI());
-			ranges.add(sfp.getShortForm(ce.getFiller().asOWLClass().getIRI()));
-			propertiesFromObjectRestrictions_ranges.put(property_name,ranges);
-		}
-
-		this.property_name = property_name;
+		this.property_name = this.sfp.getShortForm(ce.getProperty().asOWLDataProperty().getIRI());
 		
-		restrictionsValues.put(restriction, Integer.toString(ce.getCardinality()));
-		restrictionsValuesFromClass.put(property_name, restrictionsValues);
-	}
-	
-	 /**
-     * Method that given a set of ranges and properties will set them according to the boolean restriction .
-     * @param ranges a set of class ranges that compose the boolean restriction
-     * @param properties object properties expression that have the boolean restriction 
-     * @param restriction string value of restriction e.g. "unionOf"
-     */
-	public void setBooleanCombinationProperties( Set<OWLClassExpression> ranges, Set<OWLObjectProperty> properties, String restriction) {
-		Map<String, String> restrictionsValues = new HashMap<String, String>();
-		//if the expression ce is not part of a composed expression (existential or universal)
-		if (property_name.isEmpty()) {
-			for (OWLObjectProperty property: properties) {
-				propertiesFromObjectRestrictions.add(property);
-				property_name = sfp.getShortForm(property.getIRI());
-				restrictionsValues.put(restriction, "");
-				restrictionsValuesFromClass.put(property_name, restrictionsValues);
-			}
-		} else {
-			List<String> rangeList = new ArrayList<String>();
-			for (OWLClassExpression range: ranges) {
-				rangeList.add(sfp.getShortForm(range.asOWLClass().getIRI()));
-				if (range.asOWLClass().equals(owlThing)) {
-					logger.info("Ignoring owl:Thing range" + property_name);
-				} else {
-					propertiesFromObjectRestrictions_ranges.put(property_name,rangeList);
-				}
-			}
+		this.addRestrictionValueToProperty(this.property_name, "dataHasValue", ce.getFiller().getLiteral());
 			
-			if (!restrictionsValuesFromClass.isEmpty()) {
-				for (String j: restrictionsValuesFromClass.keySet()) {
-					if (j.equals(property_name)) {
-						Map<String,String> value = restrictionsValuesFromClass.get(property_name);
-						for (String i: value.keySet() ) {
-							restrictionsValues.put(restriction, i);
-						}
-
-						restrictionsValuesFromClass.put(property_name, restrictionsValues);
-					}
-				}
-			} else {
-				restrictionsValues.put(restriction, "");
-				restrictionsValuesFromClass.put(property_name, restrictionsValues);
-			}
+		for (OWLDatatype value: ce.getDatatypesInSignature()) {
+			this.addDataRestrictionRangeToProperty(this.property_name, this.sfp.getShortForm(value.getIRI()));
 		}
 	}
 	
-	 /**
-     * Method that given a set of ranges and properties will set them according to the boolean restriction .
-     * @param ranges a set of class ranges that compose the boolean restriction
-     * @param properties data properties expression that have the boolean restriction 
-     * @param restriction string value of restriction e.g. "unionOf"
-     */
-	public void setBooleanCombinationDataProperties(Set<OWLDataRange> ranges, Set<OWLDataProperty> properties, String restriction) {
-		Map<String, String> restrictionsValues = new HashMap<String, String>();
-		//if the expression ce is not part of a composed expression (existential or universal)
-		if (property_name.equals("")) {
-			for (OWLDataProperty property: properties) {
-				propertiesFromDataRestrictions.add(property);
-				property_name = sfp.getShortForm(property.getIRI());
-				restrictionsValues.put(restriction, "");
-				restrictionsValuesFromClass.put(property_name, restrictionsValues);
-			}
-		} else {
-			List<String> rangeList = new ArrayList<String>();
-			for (OWLDataRange range: ranges) {
-				rangeList.add(sfp.getShortForm(range.asOWLDatatype().getIRI()));
-				if (range.getClass().equals(owlThing)) {
-					logger.info("Ignoring owl: Thing range" + property_name);
-				} else {
-					propertiesFromDataRestrictions_ranges.put(property_name,rangeList);
-				}
-			}
-
-			if (!restrictionsValuesFromClass.isEmpty()) {
-				for (String j: restrictionsValuesFromClass.keySet()) {
-					if (j.equals(property_name)) {
-						Map<String,String> value = restrictionsValuesFromClass.get(property_name);
-						for (String i: value.keySet()) {
-							restrictionsValues.put(restriction, i);
-						}
-
-						restrictionsValuesFromClass.put(property_name, restrictionsValues);
-						break;
-					}
-				}
-			} else {
-				restrictionsValues.put(restriction, "");
-				restrictionsValuesFromClass.put(property_name, restrictionsValues);
-			}
-		}
-	}
-
-	public void setDataPropertiesWithCardinality(OWLDataCardinalityRestriction ce, String restriction) {
-		String property_name = "";
-		List<String> ranges = new ArrayList<>();
-		Map<String, String> restrictionsValues = new HashMap<>();
-		for (OWLDataProperty property: ce.getDataPropertiesInSignature()) {
-			propertiesFromDataRestrictions.add(property);
-			property_name = sfp.getShortForm(property.getIRI());
-
-			for (OWLDatatype value: ce.getDatatypesInSignature()) {
-				ranges.add(sfp.getShortForm(value.getIRI()));
-				propertiesFromDataRestrictions_ranges.put(property_name,ranges);
-			}
-		}
-
-		this.property_name = property_name;
-		restrictionsValues.put(restriction, Integer.toString(ce.getCardinality()));
-		restrictionsValuesFromClass.put(property_name, restrictionsValues);
-	}
-	
-	public Map<String, Map<String,String>> getRestrictionsValuesFromClass() {
+	/**
+	 * Getter for {@link restrictionsValuesFromClass}.
+	 * 
+	 * @return a Map of property name keys with values that contain one or more restriction name keys and restriction values
+	 */
+	public Map<String, Map<String, String>> getRestrictionsValuesFromClass() {
 		return this.restrictionsValuesFromClass;
 	}
 
-	public List<OWLObjectProperty> getPropertiesFromObjectRestrictions() {
+	/**
+	 * Getter for {@link propertiesFromObjectRestrictions}.
+	 * 
+	 * @return a Set of OWL object properties for the class
+	 */
+	public Set<OWLObjectProperty> getPropertiesFromObjectRestrictions() {
 		return this.propertiesFromObjectRestrictions;
 	}
 
-	public Map<String, List<String>> getPropertiesFromObjectRestrictions_ranges() {
+	/**
+	 * Getter for {@link propertiesFromObjectRestrictions_ranges}.
+	 * 
+	 * @return a Map of OWL object property name keys with values that contain a Set of OWL object restrictions
+	 */
+	public Map<String, Set<String>> getPropertiesFromObjectRestrictions_ranges() {
 		return this.propertiesFromObjectRestrictions_ranges;
 	}
-		
-	public List<OWLDataProperty> getPropertiesFromDataRestrictions() {
+	
+	/**
+	 * Getter for {@link propertiesFromDataRestrictions}.
+	 * 
+	 * @return a Set of OWL data properties for the class
+	 */
+	public Set<OWLDataProperty> getPropertiesFromDataRestrictions() {
 		return this.propertiesFromDataRestrictions;
 	}
 	
-	public List<String> getValuesFromDataRestrictions_ranges() {
-		return this.valuesFromDataRestrictions_ranges;
-	}
-	
-	public Map<String, List<String>> getPropertiesFromDataRestrictions_ranges() {
+	/**
+	 * Getter for {@link propertiesFromDataRestrictions_ranges}.
+	 * 
+	 * @return a Map of OWL object property name keys with values that contain a Set of OWL object restrictions
+	 */
+	public Map<String, Set<String>> getPropertiesFromDataRestrictions_ranges() {
 		return this.propertiesFromDataRestrictions_ranges;
 	}
 
-	public List<String> getEnums(IRI classIRI) {
+	/**
+	 * Getter for {@link valuesFromDataRestrictions_ranges}.
+	 * 
+	 * @return a Set of values from the OWL data restrictions
+	 */
+	public Set<String> getValuesFromDataRestrictions_ranges() {
+		return this.valuesFromDataRestrictions_ranges;
+	}
+
+	/**
+	 * Getter for a specific enumeration (enum).
+	 * 
+	 * @param classIRI an IRI of the enum name
+	 * @return a Set of short names for enum individuals
+	 */
+	public Set<String> getEnums(IRI classIRI) {
 		return this.enums.get(classIRI);
 	}
 
-	public Map<IRI, List<String>> getAllEnums() {
+	/**
+	 * Getter for map of all enumerations (enums) (i.e. {@link enums}).
+	 * 
+	 * @return a Map of IRIs (enum names) keys with values which are a Set of short names for the enum individuals
+	 */
+	public Map<IRI, Set<String>> getAllEnums() {
 		return this.enums;
 	}
 }

--- a/src/main/java/edu/isi/oba/config/YamlConfig.java
+++ b/src/main/java/edu/isi/oba/config/YamlConfig.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class YamlConfig {
   private final Map<CONFIG_FLAG, Boolean> configFlags = new HashMap<>(){{
@@ -27,14 +28,14 @@ public class YamlConfig {
   public OpenAPI openapi;
   public String output_dir = DEFAULT_OUTPUT_DIRECTORY;
   public String name = DEFAULT_PROJECT_NAME;
-  public List<String> paths;
-  public List<String> ontologies;
+  public Set<String> paths;
+  public Set<String> ontologies;
   private EndpointConfig endpoint;
   public AuthConfig auth;
   public FirebaseConfig firebase;
   public Map<String, List<RelationConfig>> relations;
   private LinkedHashMap<String, PathItem> custom_paths = null;
-  public List<String> classes;
+  public Set<String> classes;
   public String custom_queries_directory;
 
   public Boolean getEnable_get_paths() {
@@ -101,19 +102,19 @@ public class YamlConfig {
     this.name = name;
   }
 
-  public List<String> getPaths() {
+  public Set<String> getPaths() {
     return paths;
   }
 
-  public void setPaths(List<String> paths) {
+  public void setPaths(Set<String> paths) {
     this.paths = paths;
   }
 
-  public List<String>  getOntologies() {
+  public Set<String>  getOntologies() {
     return ontologies;
   }
 
-  public void setOntologies(List<String> ontologies) {
+  public void setOntologies(Set<String> ontologies) {
     this.ontologies = ontologies;
   }
 
@@ -157,11 +158,11 @@ public class YamlConfig {
     this.openapi = openapi;
   }
 
-  public List<String> getClasses() {
+  public Set<String> getClasses() {
     return this.classes;
   }
 
-  public void setClasses(List<String> classes) {
+  public void setClasses(Set<String> classes) {
     this.classes = classes;
   }
 

--- a/src/test/java/edu/isi/oba/MapperTest.java
+++ b/src/test/java/edu/isi/oba/MapperTest.java
@@ -1,27 +1,26 @@
 package edu.isi.oba;
 
-import static edu.isi.oba.ObaUtils.get_yaml_data;
 import edu.isi.oba.config.AuthConfig;
 import edu.isi.oba.config.CONFIG_FLAG;
 import edu.isi.oba.config.YamlConfig;
+import static edu.isi.oba.Oba.logger;
+import static edu.isi.oba.ObaUtils.get_yaml_data;
 
-import java.io.File;
+import io.swagger.v3.oas.models.media.Schema;
+
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.logging.ConsoleHandler;
 import java.util.logging.Level;
 import java.util.logging.LogManager;
 import java.util.logging.Logger;
 
-import io.swagger.v3.oas.models.media.Schema;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-
 import org.semanticweb.owlapi.model.OWLClass;
 
 public class MapperTest {
@@ -30,16 +29,14 @@ public class MapperTest {
         String config_test_file_path = "src/test/config/dbpedia.yaml";
         YamlConfig config_data = get_yaml_data(config_test_file_path);
         Mapper mapper = new Mapper(config_data);
-        List<String> config = config_data.getClasses();
-        List<OWLClass> classes = mapper.filter_classes();
-        List<String> filter_classes = new ArrayList();
+        Set<String> config = config_data.getClasses();
+        Set<OWLClass> classes = mapper.filter_classes();
+        Set<String> filter_classes = new HashSet<>();
         for (OWLClass _class : classes){
             filter_classes.add(_class.getIRI().getIRIString());
         }
-        Collections.sort(filter_classes);
-        Collections.sort(config);
-        Assertions.assertEquals(config, filter_classes);
 
+        Assertions.assertEquals(config, filter_classes);
     }
     
     /**
@@ -100,21 +97,20 @@ public class MapperTest {
         InputStream stream = Oba.class.getClassLoader().getResourceAsStream("logging.properties");
         try {
             LogManager.getLogManager().readConfiguration(stream);
-            edu.isi.oba.Oba.logger = Logger.getLogger(Oba.class.getName());
-
+            logger = Logger.getLogger(Oba.class.getName());
         } catch (IOException e) {
             e.printStackTrace();
         }
-        edu.isi.oba.Oba.logger.setLevel(Level.FINE);
-        edu.isi.oba.Oba.logger.addHandler(new ConsoleHandler());
+
+        logger.setLevel(Level.FINE);
+        logger.addHandler(new ConsoleHandler());
         String example_remote = "src/test/resources/complex_expr/config.yaml";
         YamlConfig config_data = get_yaml_data(example_remote);
-        String destination_dir = config_data.getOutput_dir() + File.separator + config_data.getName();
         config_data.setAuth(new AuthConfig());
         Mapper mapper = new Mapper(config_data);
         OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://businessontology.com/ontology/Person");
-        String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0), true);
-        MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), Map.ofEntries(Map.entry(CONFIG_FLAG.DEFAULT_DESCRIPTIONS, true), Map.entry(CONFIG_FLAG.DEFAULT_PROPERTIES, true), Map.entry(CONFIG_FLAG.FOLLOW_REFERENCES, true)));
+        String desc = ObaUtils.getDescription(cls, mapper.ontologies.stream().findFirst().get(), true);
+        MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.stream().findFirst().get(), Map.ofEntries(Map.entry(CONFIG_FLAG.DEFAULT_DESCRIPTIONS, true), Map.entry(CONFIG_FLAG.DEFAULT_PROPERTIES, true), Map.entry(CONFIG_FLAG.FOLLOW_REFERENCES, true)));
         Schema schema = mapperSchema.getSchema();
         // The person schema must not be null.
         Assertions.assertNotNull(schema);

--- a/src/test/java/edu/isi/oba/MapperTest.java
+++ b/src/test/java/edu/isi/oba/MapperTest.java
@@ -110,7 +110,7 @@ public class MapperTest {
         Mapper mapper = new Mapper(config_data);
         OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://businessontology.com/ontology/Person");
         String desc = ObaUtils.getDescription(cls, mapper.ontologies.stream().findFirst().get(), true);
-        MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.stream().findFirst().get(), Map.ofEntries(Map.entry(CONFIG_FLAG.DEFAULT_DESCRIPTIONS, true), Map.entry(CONFIG_FLAG.DEFAULT_PROPERTIES, true), Map.entry(CONFIG_FLAG.FOLLOW_REFERENCES, true)));
+        MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, Map.ofEntries(Map.entry(CONFIG_FLAG.DEFAULT_DESCRIPTIONS, true), Map.entry(CONFIG_FLAG.DEFAULT_PROPERTIES, true), Map.entry(CONFIG_FLAG.FOLLOW_REFERENCES, true)));
         Schema schema = mapperSchema.getSchema();
         // The person schema must not be null.
         Assertions.assertNotNull(schema);

--- a/src/test/java/edu/isi/oba/ObaUtilsTest.java
+++ b/src/test/java/edu/isi/oba/ObaUtilsTest.java
@@ -51,7 +51,7 @@ public class ObaUtilsTest {
         try {
             Mapper mapper = new Mapper(config_data);
             OWLClass planClass = mapper.manager.getOWLDataFactory().getOWLClass("http://purl.org/net/p-plan#Plan");
-            String desc = ObaUtils.getDescription(planClass, mapper.ontologies.get(0), true);
+            String desc = ObaUtils.getDescription(planClass, mapper.ontologies.stream().findFirst().get(), true);
             Assertions.assertNotEquals(desc, "");
         }catch(Exception e){
             Assertions.fail("Failed to get description.", e);
@@ -102,5 +102,4 @@ public class ObaUtilsTest {
         }catch(Exception e){
         }
     }
-
 }

--- a/src/test/java/edu/isi/oba/RestrictionsTest.java
+++ b/src/test/java/edu/isi/oba/RestrictionsTest.java
@@ -16,7 +16,6 @@ import java.util.logging.LogManager;
 import java.util.logging.Logger;
 
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import org.semanticweb.owlapi.model.OWLClass;
@@ -67,8 +66,8 @@ public class RestrictionsTest {
 			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
 			Mapper mapper = new Mapper(config_data);
 			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#University");
-			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0), true);
-			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), this.configFlags);
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.stream().findFirst().get(), true);
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, this.configFlags);
 			Schema schema = mapperSchema.getSchema();
 			Object property = schema.getProperties().get("hasRector");
 			if (property instanceof io.swagger.v3.oas.models.media.ArraySchema) {
@@ -93,8 +92,8 @@ public class RestrictionsTest {
 			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
 			Mapper mapper = new Mapper(config_data);
 			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#StudyMaterial");
-			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0), true);
-			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), this.configFlags);
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.stream().findFirst().get(), true);
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, this.configFlags);
 			Schema schema = mapperSchema.getSchema();
 			Object property = schema.getProperties().get("author");
 			if (property instanceof ArraySchema) {
@@ -127,8 +126,8 @@ public class RestrictionsTest {
 			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
 			Mapper mapper = new Mapper(config_data);
 			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#Course");
-			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0), true);
-			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), this.configFlags);
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.stream().findFirst().get(), true);
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, this.configFlags);
 			Schema schema = mapperSchema.getSchema();
 			Object property = schema.getProperties().get("hasEvaluationMethod");
 			if (property instanceof ArraySchema) {
@@ -159,8 +158,8 @@ public class RestrictionsTest {
 			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
 			Mapper mapper = new Mapper(config_data);
 			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#University");
-			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0), true);
-			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), this.configFlags);
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.stream().findFirst().get(), true);
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, this.configFlags);
 			Schema schema = mapperSchema.getSchema();
 			Object property = schema.getProperties().get("hasDepartment");
 
@@ -188,19 +187,29 @@ public class RestrictionsTest {
 			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
 			Mapper mapper = new Mapper(config_data);
 			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#Student");
-			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0), true);
-			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), this.configFlags);
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.stream().findFirst().get(), true);
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, this.configFlags);
 			Schema schema = mapperSchema.getSchema();
 			Object property = schema.getProperties().get("enrolledIn");
 			if (property instanceof ArraySchema) {
-				Boolean nullable = ((ArraySchema) property).getNullable();
 				Schema items = ((ArraySchema) property).getItems();
 				List<Schema> itemsValue;
 				if (items instanceof ComposedSchema) {
 					itemsValue = ((ComposedSchema) items).getAnyOf();
+
+					// If the anyOf list is null, something is wrong.
+					Assertions.assertNotNull(itemsValue);
+
+					// Verify the expectedResult list size and anyOf list size are equal.
+					Assertions.assertEquals(expectedResult.size(), itemsValue.size());
+
+					// The anyOf ordering may differ than the expectedResult list.
 					for (int i = 0; i < itemsValue.size(); i++) {
-						Assertions.assertEquals(expectedResult.get(i), itemsValue.get(i).get$ref());
+						expectedResult.remove(itemsValue.get(i).get$ref());
 					}
+
+					// If the expectedResult list is now empty, then both lists contained the same reference values (even if in a different order).
+					Assertions.assertEquals(expectedResult.isEmpty(), true);
 				}
 			}
 		} catch (OWLOntologyCreationException e) {
@@ -219,10 +228,10 @@ public class RestrictionsTest {
 			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
 			Mapper mapper = new Mapper(config_data);
 			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#AmericanStudent");
-			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0), true);
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.stream().findFirst().get(), true);
 
 			this.configFlags.put(CONFIG_FLAG.ALWAYS_GENERATE_ARRAYS, true);
-			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), this.configFlags);
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, this.configFlags);
 			Schema schema = mapperSchema.getSchema();
 			Object property = schema.getProperties().get("hasRecord");
 			if (property instanceof ArraySchema) {
@@ -251,11 +260,11 @@ public class RestrictionsTest {
 			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
 			Mapper mapper = new Mapper(config_data);
 			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#AmericanStudent");
-			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0), true);
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.stream().findFirst().get(), true);
 
 			this.configFlags.put(CONFIG_FLAG.ALWAYS_GENERATE_ARRAYS, false);
 			this.configFlags.put(CONFIG_FLAG.REQUIRED_PROPERTIES_FROM_CARDINALITY, true);
-			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), this.configFlags);
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, this.configFlags);
 			Schema schema = mapperSchema.getSchema();
 
 			boolean isRequired = schema.getRequired() != null && schema.getRequired().contains("hasRecord");
@@ -300,8 +309,8 @@ public class RestrictionsTest {
 			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
 			Mapper mapper = new Mapper(config_data);
 			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#AmericanStudent");
-			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0), true);
-			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), this.configFlags);
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.stream().findFirst().get(), true);
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, this.configFlags);
 			Schema schema = mapperSchema.getSchema();
 			Object property = schema.getProperties().get("takesCourse");
 			if (property instanceof ArraySchema) {
@@ -330,8 +339,8 @@ public class RestrictionsTest {
 			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
 			Mapper mapper = new Mapper(config_data);
 			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#Course");
-			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0), true);
-			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), this.configFlags);
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.stream().findFirst().get(), true);
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, this.configFlags);
 			Schema schema = mapperSchema.getSchema();
 			Object property = schema.getProperties().get("hasStudentEnrolled");
 			if (property instanceof ArraySchema) {
@@ -360,8 +369,8 @@ public class RestrictionsTest {
 			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
 			Mapper mapper = new Mapper(config_data);
 			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#ProfessorInOtherDepartment");
-			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0), true);
-			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), this.configFlags);
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.stream().findFirst().get(), true);
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, this.configFlags);
 			Schema schema = mapperSchema.getSchema();
 			if (schema.getNot() != null) {
 				Assertions.assertEquals(expectedResult, schema.getNot().get$ref());
@@ -391,8 +400,8 @@ public class RestrictionsTest {
 			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
 			Mapper mapper = new Mapper(config_data);
 			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#ProfessorInArtificialIntelligence");
-			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0), true);
-			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), this.configFlags);
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.stream().findFirst().get(), true);
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, this.configFlags);
 			Schema schema = mapperSchema.getSchema();
 			Object property = schema.getProperties().get("belongsTo");
 
@@ -427,26 +436,38 @@ public class RestrictionsTest {
 		try {
 			this.initializeLogger();
 			List<String> expectedResult = new ArrayList<String>();
-			expectedResult.add("<https://w3id.org/example/resource/Degree/MS>");
-			expectedResult.add("<https://w3id.org/example/resource/Degree/PhD>");
+			// Original full IRIs were:
+			// expectedResult.add("<https://w3id.org/example/resource/Degree/MS>");
+			// expectedResult.add("<https://w3id.org/example/resource/Degree/PhD>");
+			// Because these are individuals which may up the (sub)set of the Degree enum, we only need their short form name now:
+			expectedResult.add("MS");
+			expectedResult.add("PhD");
 			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
 			Mapper mapper = new Mapper(config_data);
 			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#Professor");
-			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0), true);
-			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), this.configFlags);
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.stream().findFirst().get(), true);
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, this.configFlags);
 			Schema schema = mapperSchema.getSchema();
 			Object property = schema.getProperties().get("hasDegree");
 
 			if (property instanceof ArraySchema) {
 				Schema items = ((ArraySchema) property).getItems();
-				List<Object> itemsValue;
 				if (items instanceof ComposedSchema) {
-					itemsValue = ((ComposedSchema) items).getEnum();
-					for (int i = 0; i < itemsValue.size(); i++) {
-						Object ref = itemsValue.get(i);
-						Assertions.assertEquals(expectedResult.get(i), ref.toString());
+					final var oneOfValues = ((ComposedSchema) items).getOneOf();
+					if (oneOfValues != null && !oneOfValues.isEmpty()) {
+						final var enumValues = oneOfValues.iterator().next().getEnum();
+						for (int i = 0; i < enumValues.size(); i++) {
+							Object ref = enumValues.get(i);
+							Assertions.assertEquals(expectedResult.get(i), ref.toString());
+						}
+					} else {
+						Assertions.fail("Property's oneOf items do not exist.");
 					}
+				} else {
+					Assertions.fail("Property's items are not a composed schema type.");
 				}
+			} else {
+				Assertions.fail("Property is not an array schema type.");
 			}
 		} catch (OWLOntologyCreationException e) {
 			Assertions.fail("Error in ontology creation: ", e);
@@ -464,8 +485,8 @@ public class RestrictionsTest {
 			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
 			Mapper mapper = new Mapper(config_data);
 			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#AmericanStudent");
-			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0), true);
-			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), this.configFlags);
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.stream().findFirst().get(), true);
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, this.configFlags);
 			Schema schema = mapperSchema.getSchema();
 			Object property = schema.getProperties().get("birthDate");
 			if (property instanceof io.swagger.v3.oas.models.media.ArraySchema) {
@@ -490,9 +511,12 @@ public class RestrictionsTest {
 
 			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
 			Mapper mapper = new Mapper(config_data);
+
+
 			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#Course");
-			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0), true);
-			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), this.configFlags);
+
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.stream().findFirst().get(), true);
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, this.configFlags);
 			Schema schema = mapperSchema.getSchema();
 			Object property = schema.getProperties().get("ects");
 			if (property instanceof ArraySchema) {
@@ -527,8 +551,8 @@ public class RestrictionsTest {
 			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
 			Mapper mapper = new Mapper(config_data);
 			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#ProfessorInArtificialIntelligence");
-			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0), true);
-			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), this.configFlags);
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.stream().findFirst().get(), true);
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, this.configFlags);
 			Schema schema = mapperSchema.getSchema();
 			Object property = schema.getProperties().get("memberOfOtherDepartments");
 			if (property instanceof ArraySchema) {
@@ -550,7 +574,6 @@ public class RestrictionsTest {
 	/**
 	 * This test attempts to get the OAS representation of the SomeValuesFrom restriction of a DataProperty.
 	 */
-	@Disabled
 	@Test
 	public void testDataSomeValuesFrom() throws OWLOntologyCreationException, Exception {
 		try {
@@ -559,14 +582,14 @@ public class RestrictionsTest {
 			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
 			Mapper mapper = new Mapper(config_data);
 			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#StudyProgram");
-			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0), true);
-			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), this.configFlags);
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.stream().findFirst().get(), true);
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, this.configFlags);
 			Schema schema = mapperSchema.getSchema();
 			Object property = schema.getProperties().get("studyProgramName");
 			if (property instanceof ArraySchema) {
 				Boolean nullable = ((ArraySchema) property).getNullable();
 				Assertions.assertEquals(expectedResult, ((ArraySchema) property).getItems().getType());
-				Assertions.assertEquals(false, nullable);
+				Assertions.assertEquals(true, nullable);
 			}
 		} catch (OWLOntologyCreationException e) {
 			Assertions.fail("error in ontology creation: ", e);
@@ -587,8 +610,8 @@ public class RestrictionsTest {
 			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
 			Mapper mapper = new Mapper(config_data);
 			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#ProfessorInArtificialIntelligence");
-			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0), true);
-			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), this.configFlags);
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.stream().findFirst().get(), true);
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, this.configFlags);
 			Schema schema = mapperSchema.getSchema();
 			Object property = schema.getProperties().get("memberOfOtherDepartments");
 			if (property instanceof ArraySchema) {
@@ -602,7 +625,7 @@ public class RestrictionsTest {
 					}
 				}
 
-				Assertions.assertEquals(false, nullable);
+				Assertions.assertEquals(true, nullable);
 			}
 		} catch (OWLOntologyCreationException e) {
 			Assertions.fail("error in ontology creation: ", e);
@@ -620,8 +643,8 @@ public class RestrictionsTest {
 			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
 			Mapper mapper = new Mapper(config_data);
 			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#StudyProgram");
-			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0), true);
-			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), this.configFlags);
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.stream().findFirst().get(), true);
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, this.configFlags);
 			Schema schema = mapperSchema.getSchema();
 			Object property = schema.getProperties().get("studyProgramName");
 			if (property instanceof ArraySchema) {
@@ -645,8 +668,8 @@ public class RestrictionsTest {
 			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
 			Mapper mapper = new Mapper(config_data);
 			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#Person");
-			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0), true);
-			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), this.configFlags);
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.stream().findFirst().get(), true);
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, this.configFlags);
 			Schema schema = mapperSchema.getSchema();
 			Object property = schema.getProperties().get("gender");
 			if (property instanceof ArraySchema) {
@@ -677,8 +700,8 @@ public class RestrictionsTest {
 			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
 			Mapper mapper = new Mapper(config_data);
 			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#AmericanStudent");
-			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0), true);
-			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), this.configFlags);
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.stream().findFirst().get(), true);
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, this.configFlags);
 			Schema schema = mapperSchema.getSchema();
 			Object property = schema.getProperties().get("nationality");
 			
@@ -704,8 +727,8 @@ public class RestrictionsTest {
 			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
 			Mapper mapper = new Mapper(config_data);
 			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#University");
-			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0), true);
-			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), this.configFlags);
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.stream().findFirst().get(), true);
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, this.configFlags);
 			Schema schema = mapperSchema.getSchema();
 			Object property = schema.getProperties().get("universityName");
 
@@ -747,8 +770,8 @@ public class RestrictionsTest {
 			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
 			Mapper mapper = new Mapper(config_data);
 			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#Professor");
-			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0), true);
-			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), this.configFlags);
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.stream().findFirst().get(), true);
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, this.configFlags);
 			Schema schema = mapperSchema.getSchema();
 			Object property = schema.getProperties().get("researchField");
 			Integer minItems = ((ArraySchema) property).getMinItems();
@@ -774,8 +797,8 @@ public class RestrictionsTest {
 			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
 			Mapper mapper = new Mapper(config_data);
 			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#Person");
-			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0), true);
-			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), this.configFlags);
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.stream().findFirst().get(), true);
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, this.configFlags);
 			Schema schema = mapperSchema.getSchema();
 			Object property = schema.getProperties().get("address");
 			Integer maxItems = ((ArraySchema) property).getMaxItems();
@@ -801,8 +824,8 @@ public class RestrictionsTest {
 			YamlConfig config_data = get_yaml_data("examples/restrictions/config.yaml");
 			Mapper mapper = new Mapper(config_data);
 			OWLClass cls = mapper.manager.getOWLDataFactory().getOWLClass("https://w3id.org/example#Department");
-			String desc = ObaUtils.getDescription(cls, mapper.ontologies.get(0), true);
-			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, mapper.ontologies.get(0), this.configFlags);
+			String desc = ObaUtils.getDescription(cls, mapper.ontologies.stream().findFirst().get(), true);
+			MapperSchema mapperSchema = new MapperSchema(mapper.ontologies, cls, desc, mapper.schemaNames, this.configFlags);
 			Schema schema = mapperSchema.getSchema();
 			Object property = schema.getProperties().get("numberOfProfessors");
 

--- a/src/test/java/edu/isi/oba/config/YamlConfigTest.java
+++ b/src/test/java/edu/isi/oba/config/YamlConfigTest.java
@@ -2,8 +2,7 @@ package edu.isi.oba.config;
 
 import static edu.isi.oba.ObaUtils.get_yaml_data;
 
-import java.util.Arrays;
-import java.util.List;
+import java.util.Set;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -13,8 +12,8 @@ public class YamlConfigTest {
     public void getSelectedClasses(){
         String config_test_file_path = "examples/dbpedia/config_music.yaml";
         YamlConfig config_data = get_yaml_data(config_test_file_path);
-        List<String> expected = Arrays.asList("http://dbpedia.org/ontology/Genre", "http://dbpedia.org/ontology/Band");
-        List<String> config = config_data.getClasses();
+        Set<String> expected = Set.of("http://dbpedia.org/ontology/Genre", "http://dbpedia.org/ontology/Band");
+        Set<String> config = config_data.getClasses();
         Assertions.assertEquals(expected, config);
     }
 }


### PR DESCRIPTION
This PR will be very difficult to review.  Apologies in advance for this!

I was looking through other issues and noticed [issue #93 Range with complex objects (using other schemas) makes OBA not recognize all classes](https://github.com/KnowledgeCaptureAndDiscovery/OBA/issues/93).  I noticed the range for `asociadaA` was a `unionOf` two classes and it was being used at least once with exact cardinality.  This got me started looking to see if I could further fix/improve complex restrictions.

The closer I got to it working correctly, the more I realized I was reusing/condensing a lot of the existing `RestrictionVisitor` code.  I ended up with 3 helper methods to store the properties/restrictions in the Set and Map variables.  Several visit types (e.g. `OWLNaryBooleanClassExpression` versus `OWLObjectUnionOf` and `OWLObjectIntersectionOf`) were virtually identical, except for the restriction values key.  For all of these, I made helper methods and inferred the key based on the subinterface.

Also added comments and fixes where it became easier to identify issues due to code cleanup.  For this re-write, it also eventually became clear that enums are basically class restrictions (rather than properties) and can be handled here also.  The caveat is that the property is an empty string (because it's not a property!).  This is treated as a special case check in `MapperSchema`, which builds the enum schema upon encountering this restriction.

There were some adjustments that needed to be made in `Mapper` and `MapperSchema` due to the `RestrictionVisitor` changes.  Perhaps the biggest issue that I ran into when using the ontology from [issue #93 Range with complex objects (using other schemas) makes OBA not recognize all classes](https://github.com/KnowledgeCaptureAndDiscovery/OBA/issues/93), is that it didn't generate endpoints or models for classes based on the ontology's IRI.  This may require some discussion.

Throughout, I updated most of the lists to sets.  I did this partly by comparing examples from [owlapi TutorialSnippetsTestCase](https://github.com/owlcs/owlapi/blob/version5/contract/src/test/java/uk/ac/manchester/owl/owlapi/tutorialowled2011/TutorialSnippetsTestCase.java) and partly by realizing this allowed us to only pass the `OWLClass` object around and determine which ontology it was part of.  (There may be a better way overall, but I was trying to make incremental improvements, including readability and code usability/write-ability).

Lastly, I encountered several things the appeared to be bugs.  For example, data type `nonPositiveInteger` would map to the `integer` type in the spec - but if you have `nonPositiveInteger` and `nonNegativeInteger` then you'd have two (generic) integer entries in the `items` list; this completely misses the fact that it is basically saying "only zero is allowed".

"oneOf" references to enum values should just use the individual's short form (in my opinion) like the enum classes and not use `format: uri` and `type: string`, in order to align with the enums.  But, if this is necessary, I am OK with using a configuration flag to flip between the two methods.

Unions and intersections appear to be working correctly now for me, but I was seeing bugs (i.e. missing OpenAPI spec details) in some cases, such as `StudyMaterial` from the `example.owl` file.  Inheritance was also not working in some cases.  For example, `hasDegree` was missing on `Student`, despite it existing on its superclass `Person`.

The only two issues that I am aware of from restrictions and schema models now:
1. Property nullability and requiredness need to be reviewed (to make sure nothing is wrong or missing).
2. Complex unions/intersections (e.g. the `testObjectUnionOf` in `example.owl`) create `anyOf` AND `allOf` arrays under `items` - each having all of the range values conflated together.  (To fix this will require a re-write of `RestrictionVisitor` and the mapper classes and be a big undertaking.)